### PR TITLE
Tidy prints spurious errors when editing HTML5

### DIFF
--- a/syntax_checkers/html.vim
+++ b/syntax_checkers/html.vim
@@ -23,7 +23,7 @@ function! SyntaxCheckers_html_GetLocList()
 
     "grep out the '<table> lacks "summary" attribute' since it is almost
     "always present and almost always useless
-    let makeprg="tidy -e ".shellescape(expand('%'))." 2>&1 \\| grep -v '\<table\> lacks \"summary\" attribute'"
+    let makeprg="tidy --new-blocklevel-tags 'section, article, aside, hgroup, header, footer, nav, figure, figcaption' --new-inline-tags 'video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist' --new-empty-tags 'wbr, keygen' -e ".shellescape(expand('%'))." 2>&1 \\| grep -v '\<table\> lacks \"summary\" attribute' \\| grep -v 'not approved by W3C'"
     let errorformat='%Wline %l column %c - Warning: %m,%Eline %l column %c - Error: %m,%-G%.%#,%-G%.%#'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
While getting Tidy to really check the validity of HTML5 documents would be difficult and probably premature, it's fairly easy to get Tidy to stop generating errors when it encounters one of the new elements found in the spec.

The attached commit updates the HTML syntax checker to suppress these errors.
