### PR TITLE
Fix the problem of Error window refusing to open after manually closing when g:syntastic_auto_loc_list enabled.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -41,6 +41,9 @@ runtime! syntax_checkers/*.vim
 "refresh and redraw all the error info for this buf when saving or reading
 autocmd bufreadpost,bufwritepost * call s:UpdateErrors()
 function! s:UpdateErrors()
+    if &buftype == 'quickfix'
+        return
+    endif
     call s:CacheErrors()
 
     if g:syntastic_enable_signs


### PR DESCRIPTION
If `g:syntastic_auto_loc_list` is enabled, everything works fine (the window opens and closes properly) but there is a problem where if you close the window with the `:lclose` command, then try to open it again with either `:Errors` or `:lopen` the window will not open.  The problem is that one of the `autocmd` calls is getting called on the `location list` window.  To fix this, I added a test to make sure we're not running our syntax checker on the quickfix and/or location list window.
