### PR TITLE
This is a minor change so that the location list will automatically close if it's open.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -59,11 +59,11 @@ function! s:UpdateErrors()
         if g:syntastic_auto_jump
             silent!ll
         endif
-    elseif g:syntastic_auto_loc_list == 2 || g:syntastic_auto_loc_list =~ "semi_auto"
+    elseif g:syntastic_auto_loc_list == 2
         lclose
     endif
 
-    if g:syntastic_auto_loc_list == 1 || g:syntastic_auto_loc_list =~ "fully\\?_auto"
+    if g:syntastic_auto_loc_list == 1
         if s:BufHasErrorsOrWarningsToDisplay()
             call s:ShowLocList()
         else


### PR DESCRIPTION
The auto_loc_list behavior normally opens and closes the list automatically.  I tend to use a function a keybinding to open and close the location list ([see here for the binding](http://vim.wikia.com/wiki/Toggle_to_open_or_close_the_quickfix_window)).

Anyways, this edit allows one to set auto_loc_list to -1 and the list will be automatically closed if there are no more errors.
