### PR TITLE
Ignore tags generated by vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Added doc/tags to .gitignore because when managing vim plugins with
git submodules the generated tags makes the repository "dirty".
