### PR TITLE
UTF-8 flag for (X)HTML

### DIFF
--- a/syntax_checkers/html.vim
+++ b/syntax_checkers/html.vim
@@ -23,7 +23,7 @@ function! SyntaxCheckers_html_GetLocList()
 
     "grep out the '<table> lacks "summary" attribute' since it is almost
     "always present and almost always useless
-    let makeprg="tidy --new-blocklevel-tags 'section, article, aside, hgroup, header, footer, nav, figure, figcaption' --new-inline-tags 'video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist' --new-empty-tags 'wbr, keygen' -e ".shellescape(expand('%'))." 2>&1 \\| grep -v '\<table\> lacks \"summary\" attribute' \\| grep -v 'not approved by W3C'"
+    let makeprg="tidy -utf8 --new-blocklevel-tags 'section, article, aside, hgroup, header, footer, nav, figure, figcaption' --new-inline-tags 'video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist' --new-empty-tags 'wbr, keygen' -e ".shellescape(expand('%'))." 2>&1 \\| grep -v '\<table\> lacks \"summary\" attribute' \\| grep -v 'not approved by W3C'"
     let errorformat='%Wline %l column %c - Warning: %m,%Eline %l column %c - Error: %m,%-G%.%#,%-G%.%#'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 

--- a/syntax_checkers/xhtml.vim
+++ b/syntax_checkers/xhtml.vim
@@ -21,7 +21,7 @@ endif
 
 function! SyntaxCheckers_xhtml_GetLocList()
 
-    let makeprg="tidy -xml -e ".shellescape(expand('%'))
+    let makeprg="tidy -utf8 -xml -e ".shellescape(expand('%'))
     let errorformat='%Wline %l column %c - Warning: %m,%Eline %l column %c - Error: %m,%-G%.%#,%-G%.%#'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
I use Russian text in UTF-8 in (X)HTML and without -utf8 flat tidy makes this text a pile of garbage by escaping it with HTML-entities. I had to add this option into syntax checker to avoid this behavior and preserve UTF-8 characters. Maybe it will be useful for other users.
