### PR TITLE
Add syntax checker for matlab/octave files

### DIFF
--- a/syntax_checkers/matlab.vim
+++ b/syntax_checkers/matlab.vim
@@ -1,0 +1,34 @@
+"============================================================================
+"File:        matlab.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Jason Graham <jason at the-graham dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("loaded_matlab_syntax_checker")
+	finish
+endif
+let loaded_matlab_syntax_checker = 1
+
+"bail if the user doesn't have mlint installed
+if !executable("mlint")
+	finish
+endif
+
+function! SyntaxCheckers_matlab_GetLocList()
+	let makeprg = 'mlint -id $* '.shellescape(expand('%'))
+	let errorformat = 'L %l (C %c): %*[a-zA-Z0-9]: %m,L %l (C %c-%*[0-9]): %*[a-zA-Z0-9]: %m'
+	let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+
+	for i in loclist
+		let i['bufnr'] = bufnr("")
+	endfor
+
+	return loclist
+endfunction
+


### PR DESCRIPTION
 Needs `mlint` (distributed with Matlab) in your `$PATH`.  Tested on both Windows and Linux.
