### PR TITLE
css.vim - Fixed line/col printing in error description.

### DIFF
--- a/syntax_checkers/css.vim
+++ b/syntax_checkers/css.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_css_GetLocList()
     let makeprg = 'csslint '.shellescape(expand('%'))
 
     " Print CSS Lint's 'Welcome' and error/warning messages. Ignores the code line.
-    let errorformat  = '%+Gcsslint:\ There%.%#,%A%f:,%C%n:\ %t%\\w%\\+\ at\ line\ %l\,\ col\ %c,%Z%m\ at\ line%.%#,%A%>%f:,%C%n:\ %t%\\w%\\+\ at\ line\ %l\,\ col\ %c,%Z%m,%-G%.%#'
+    let errorformat = '%+Gcsslint:\ There%.%#,%A%f:,%C%n:\ %t%\\w%\\+\ at\ line\ %l\,\ col\ %c,%Z%m\ at\ line%.%#,%A%>%f:,%C%n:\ %t%\\w%\\+\ at\ line\ %l\,\ col\ %c,%Z%m,%-G%.%#'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
It was caused by an inconsistency of CSS Lint's output:

Errors included line/col in the error's description, while warnings did not. It is now fixed.
