### PR TITLE
Improving Haskell support

### DIFF
--- a/syntax_checkers/haskell.vim
+++ b/syntax_checkers/haskell.vim
@@ -14,15 +14,15 @@ if exists("loaded_haskell_syntax_checker")
 endif
 let loaded_haskell_syntax_checker = 1
 
-"bail if the user doesnt have ghc installed
-if !executable("ghc")
+"bail if the user doesnt have ghc-mod installed
+if !executable("ghc-mod")
     finish
 endif
 
-" As this calls ghc, it can take a few seconds... maybe hlint or something
-" could do a good enough job?
 function! SyntaxCheckers_haskell_GetLocList()
-    let makeprg = 'ghc '.shellescape(expand('%')).' -e :q'
+    let makeprg = 
+          \ 'ghc-mod check '. shellescape(expand('%')) .
+          \ ' && ghc-mod lint ' . shellescape(expand('%'))
     let errorformat = '%-G\\s%#,%f:%l:%c:%m,%E%f:%l:%c:,%Z%m,'
 
 


### PR DESCRIPTION
Previously ghc was being used, but this was not good because
ghc would work only on individual files. As soon you included
an external module also developed on the current project, ghc would
barf at you saying that the module couldn't be found. ghc-mod
doesn't check dependencies, just syntax, also it has the lint
utility that is pretty handy.
