### PR TITLE
Modifies the sass checker to use the --compass switch.

### DIFF
--- a/syntax_checkers/sass.vim
+++ b/syntax_checkers/sass.vim
@@ -24,7 +24,7 @@ let g:syntastic_sass_imports = 0
 function! SyntaxCheckers_sass_GetLocList()
     "use compass imports if available
     if g:syntastic_sass_imports == 0 && executable("compass")
-        let g:syntastic_sass_imports = system("compass imports")
+        let g:syntastic_sass_imports = "--compass"
     else
         let g:syntastic_sass_imports = ""
     endif


### PR DESCRIPTION
Hi. I was having some errors in the syntax checking for sass that didn't bother the sass compiler itself. I submitted my observation to the sass mailing list and here's the discussion:

http://groups.google.com/group/compass-users/browse_thread/thread/39419abb901cddcd#

tl;dr: It seems that they prefer to use the --compass switch instead of doing `compass imports` in the sass checker.
