### PR TITLE
Added support for the Closure Linter

### DIFF
--- a/syntax_checkers/javascript.vim
+++ b/syntax_checkers/javascript.vim
@@ -29,7 +29,7 @@ if executable("gjslint")
             let gjslintconf = g:syntastic_gjslint_conf
         endif
         let makeprg = "gjslint" . gjslintconf . " --nosummary --unix_mode --nodebug_indentation --nobeep " . shellescape(expand('%'))
-        let errorformat="%f:%l:(%n)\ %m,%-G1 files checked, no errors found.,%-G%.%#"
+        let errorformat="%f:%l:(New Error %n) %m,%f:%l:(%n) %m,%-G1 files checked, no errors found.,%-G%.%#"
         return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
     endfunction
     " We're using google gjslint, finished.


### PR DESCRIPTION
I threw in support for the closure linter we're using, I'm not sure if the scanf error formats are "correct" (there's probably a better way to do ignore the "1 files checked..." message) but it seems to work well.

Thanks for making this plugin, it's awesome.

-Andy
