### PR TITLE
FreeBSD shell workaround

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -19,6 +19,10 @@ let g:loaded_syntastic_plugin = 1
 
 let s:running_windows = has("win16") || has("win32") || has("win64")
 
+if !s:running_windows
+    let s:uname = system('uname')
+endif
+
 if !exists("g:syntastic_enable_signs") || !has('signs')
     let g:syntastic_enable_signs = 0
 endif
@@ -258,7 +262,7 @@ function! SyntasticMake(options)
     let old_shell = &shell
     let old_errorformat = &errorformat
 
-    if !s:running_windows
+    if !s:running_windows && (s:uname !~ "FreeBSD")
         "this is a hack to stop the screen needing to be ':redraw'n when
         "when :lmake is run. Otherwise the screen flickers annoyingly
         let &shellpipe='&>'


### PR DESCRIPTION
Hi, thanks for a great plugin!

I've made a workaround in `lmake` wrapper to make shell settings suitable for FreeBSD: Linux' `/bin/bash` in FreeBSD is nonsense so your plugin didn't work on FreeBSD out of the box. Now it does.
