### PR TITLE
don't break when efm_perl.pl isn't executable

### DIFF
--- a/syntax_checkers/perl.vim
+++ b/syntax_checkers/perl.vim
@@ -24,7 +24,7 @@ if !executable("perl")
 endif
 
 if !exists("g:syntastic_perl_efm_program")
-    let g:syntastic_perl_efm_program = $VIMRUNTIME.'/tools/efm_perl.pl -c'
+    let g:syntastic_perl_efm_program = 'perl '.$VIMRUNTIME.'/tools/efm_perl.pl -c'
 endif
 
 function! SyntaxCheckers_perl_GetLocList()


### PR DESCRIPTION
On my CentOS box, the efm_perl.pl isn't executable, so this just runs the syntax checker through the perl executable.
