### PR TITLE
Counter-hack to provide screen redraw on FreeBSD

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -286,6 +286,10 @@ function! SyntasticMake(options)
     let &shellpipe=old_shellpipe
     let &shell=old_shell
 
+    if s:uname =~ "FreeBSD"
+        redraw!
+    endif
+
     return errors
 endfunction
 


### PR DESCRIPTION
I'd attempted to find something useful in the sh/csh/tcsh man pages to
get similar shell redirection that &>/>& does, but it appears that all
fds are redirected, not just stderr and stdout.
