### PR TITLE
Updating the haskell syntax checker

### DIFF
--- a/syntax_checkers/haskell.vim
+++ b/syntax_checkers/haskell.vim
@@ -21,10 +21,10 @@ endif
 
 function! SyntaxCheckers_haskell_GetLocList()
     let makeprg = 
-          \ "{". 
-          \ "ghc-mod check ". shellescape(expand('%')) . ";" .
-          \ 'ghc-mod lint ' . shellescape(expand('%')) . ";" .
-          \ "}"
+          \ "{ ". 
+          \ "ghc-mod check ". shellescape(expand('%')) . "; " .
+          \ "ghc-mod lint " . shellescape(expand('%')) . ";" .
+          \ " }"
     let errorformat = '%-G\\s%#,%f:%l:%c:%m,%E%f:%l:%c:,%Z%m,'
 
 


### PR DESCRIPTION
The previous implementation was crashing the :make vim utility on Linux boxes (both Ubuntu and ArchLinux). After saving a file, it was required to use :redraw! in order to keep using the editor.

After a lot of investigation, I realized that the use of "&&" in commands is not of the like to :make.

The use of the "&&" command was updated with "{ commad1; command2 }" approach (check the diff of the commit), this way we got the result we wanted without any obnoxious side effect.
