### PR TITLE
Changed the C syntax checker to use GNU99 (as opposed to GNU89).

### DIFF
--- a/syntax_checkers/c.vim
+++ b/syntax_checkers/c.vim
@@ -82,7 +82,7 @@ function! s:Init()
 endfunction
 
 function! SyntaxCheckers_c_GetLocList()
-    let makeprg = 'gcc -fsyntax-only '.shellescape(expand('%')).' -I. -I..'
+    let makeprg = 'gcc -fsyntax-only -std=gnu99 '.shellescape(expand('%')).' -I. -I..'
     let errorformat = '%-G%f:%s:,%-G%f:%l: %#error: %#(Each undeclared '.
                \ 'identifier is reported only%.%#,%-G%f:%l: %#error: %#for '.
                \ 'each function it appears%.%#,%-GIn file included%.%#,'.


### PR DESCRIPTION
Is there really anyone who doesn't at least use "for(int i.." at this point?
Maybe this should be made into an option instead.
