### PR TITLE
Display messages for csslint.

### DIFF
--- a/syntax_checkers/css.vim
+++ b/syntax_checkers/css.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_css_GetLocList()
     let makeprg = 'csslint --format=compact '.shellescape(expand('%'))
 
     " Print CSS Lint's error/warning messages from compact format. Ignores blank lines.
-    let errorformat = '%f: line %l\, col %c\, %m,%-G'
+    let errorformat = '%f: line %l\, col %c\, %m,%-G,%-G%f: lint free!'
 
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
Simplify patterns and specify compact format for csslint cli.

This fixes #55 (or at least makes it functional).
