### PR TITLE
Add line to documentation so the statusline is set correctly

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -85,6 +85,7 @@ To use the statusline flag, this must appear in your |'statusline'| setting >
 <
 Something like this could be more useful: >
     set statusline+=%#warningmsg#
+    set statusline+=%*
     set statusline+=%{SyntasticStatuslineFlag()}
     set statusline+=%*
 <


### PR DESCRIPTION
I added a line to the documentation which suggests prepending the `%{SyntasticStatuslineFlag()}` in the status line with a `%*`. I could not get syntastic to work without this. I'm not [the first to come across this](https://github.com/scrooloose/syntastic/issues/1) so maybe we can change the documentation.
