### PR TITLE
Add --ignoreimport to puppet parse

### DIFF
--- a/syntax_checkers/puppet.vim
+++ b/syntax_checkers/puppet.vim
@@ -29,7 +29,7 @@ function! SyntaxCheckers_puppet_GetLocList()
             \ shellescape(expand('%')) .
             \ ' --color=false'
     else
-      let makeprg = 'puppet --color=false --parseonly '.shellescape(expand('%'))
+      let makeprg = 'puppet --color=false --parseonly --ignoreimport '.shellescape(expand('%'))
     endif
 
     let errorformat = 'err: Could not parse for environment %*[a-z]: %m at %f:%l'


### PR DESCRIPTION
Without --ignoreimport if you import in a manifest vim will end up editing the imported file rather than the original file specified on the command line.  This fixes that.
