### PR TITLE
Added the ability to pass flags into the phpcs command for PHP syntax checking

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -28,7 +28,11 @@ endfunction
 function! SyntaxCheckers_php_GetLocList()
 
     let errors = []
-    if executable("phpcs")
+
+    let no_phpcs = exists("g:syntastic_phpcs_disable") && g:syntastic_phpcs_disable
+
+    " Run phpcs if it is found, and if it is not disabled.
+    if executable("phpcs") && !no_phpcs
         " Support passing configuration directives to phpcs through
         " g:syntastic_phpcs_conf. This matches the method in the javascript.vim
         " setup.
@@ -38,7 +42,6 @@ function! SyntaxCheckers_php_GetLocList()
           let phpcsconf = g:syntastic_phpcs_conf
         endif
         let makeprg = "phpcs " . phpcsconf . " --report=csv ".shellescape(expand('%'))
-        let g:mpb_makeprg = makeprg
         let errorformat = '"%f"\,%l\,%c\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]'
         let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
     endif


### PR DESCRIPTION
PHPCS has a wide variety of flags and options. I added a small bit to allow a user to set g:syntastic_phpcs_conf to pass this configuration to phpcs.

I based this mainly on the javascript.vim setup, hoping that that is "the right way".
