### PR TITLE
sign throwing error during open on terminal

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -27,8 +27,8 @@ if !exists("g:syntastic_enable_signs")
     let g:syntastic_enable_signs = has('signs')? 1 : 0
 endif
 
-if !exists("g:syntastic_enable_balloons") || !has('balloon_eval')
-    let g:syntastic_enable_balloons = 1
+if !exists("g:syntastic_enable_balloons")
+    let g:syntastic_enable_balloons = has('balloon_eval')? 1 : 0
 endif
 
 if !exists("g:syntastic_auto_loc_list")


### PR DESCRIPTION
I'm getting the following error when opening Vim on terminal/iTerm2 after I upgraded syntastic:

```
Error detected while processing /Users/millermedeiros/Dropbox/vim/vim/bundle/syntastic/plugin/syntastic.vim:
line  191:
E319: Sorry, the command is not available in this version:     sign define SyntasticError text=>> texthl=error
```

vim version 7.2.108 running on MacOSX 10.6.8

this patch will fix it (since I only enable signs if they are available)

cheers.
