### PR TITLE
add applescript syntax_checker

### DIFF
--- a/syntax_checkers/applescript.vim
+++ b/syntax_checkers/applescript.vim
@@ -3,16 +3,19 @@
 "           Desc: Syntax checking plugin for syntastic.vim
 "         Author: Zhao Cai
 "          Email: caizhaoff@gmail.com
-"        Version: 0.1
+"        Version: 0.2.1
 "   Date Created: Thu 09 Sep 2011 10:30:09 AM EST 
-"  Last Modified: Fri 09 Dec 2011 10:32:04 AM EST 
+"  Last Modified: Fri 09 Dec 2011 01:10:24 PM EST 
 "
-"        History: 0.1 - working, but it will run the script everytime to check
+"        History: 0.1.0 - working, but it will run the script everytime to check
 "                 syntax. Should use osacompile but strangely it does not give
 "                 errors.
 "
-"                 0.1.1 - switch to osacompile, it gives less errors compared
+"                 0.2.0 - switch to osacompile, it gives less errors compared
 "                 with osascript.
+"
+"                 0.2.1 - remove g:syntastic_applescript_tempfile. use
+"                 tempname() instead.
 "
 "        License: This program is free software. It comes without any
 "        warranty, to the extent permitted by applicable law. You can
@@ -32,21 +35,8 @@ if !executable("osacompile")
     finish
 endif
 
-if !exists("g:syntastic_applescript_tempfile")
-    echohl WarningMsg
-    echom "set g:syntastic_applescript_tempfile = /path/to/file.scpt is recommanded."
-    echohl NONE
-
-    let s:osacompile = 'osacompile -o ' . shellescape(expand('%:p:r') . '.scpt')
-else
-    if &verbose > 1 && filereadable(g:syntastic_applescript_tempfile)
-        echom g:syntastic_applescript_tempfile . ' exists. Make sure it is OK to overwrite!'
-    endif
-    let s:osacompile = 'osacompile -o ' . g:syntastic_applescript_tempfile
-endif
-
 function! SyntaxCheckers_applescript_GetLocList()
-    let makeprg = s:osacompile .' '. shellescape(expand('%'))
+    let makeprg = 'osacompile -o ' . tempname() . '.scpt '. shellescape(expand('%'))
     let errorformat = '%f:%l:%m'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
applescript syntax_checker for mac 

Option:

```
    let g:syntastic_applescript_tempfile = 'path/to/tmp/syntastic-applescript-temp.scpt'
```
