### PR TITLE
Added the --standard=Zend flag as default

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -21,7 +21,7 @@ endif
 
 "Support passing configuration directives to phpcs
 if !exists("g:syntastic_phpcs_conf")
-    let g:syntastic_phpcs_conf = ""
+    let g:syntastic_phpcs_conf = "--standard=Zend"
 endif
 
 if !exists("g:syntastic_phpcs_disable")


### PR DESCRIPTION
I changed the default standard to Zend, which seems to be the most forgiving of the ones built-in. Should users so desire, they can change to alternate syntaxes.
