### PR TITLE
Support for filetype names containing hyphens

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -139,7 +139,7 @@ function! s:CacheErrors()
     let b:syntastic_loclist = []
 
     if filereadable(expand("%"))
-        for ft in split(&ft, '\.')
+        for ft in split(substitute(&ft, '-', '_', 'g'), '\.')
             if s:Checkable(ft)
                 let b:syntastic_loclist = extend(b:syntastic_loclist, SyntaxCheckers_{ft}_GetLocList())
             endif


### PR DESCRIPTION
The gentoo vim syntax files use names like gentoo-mirrors, gentoo-metadata, etc.  We also have some  filetype plugins at the office that use prefixing for grouping, and I'd like to use syntastic with them too.

This simple, and very ugly, fix makes it possible to write syntax checkers for them.  I'm sure there must be a much better way to accomplish this, but I just don't know it.

While I have your attention with this, is it possible to alias the syntax checkers somehow?  For example, the standard XML checker would work equally well for gentoo-metadata.

Thanks,

James
