### PR TITLE
fix jshint checker since it was ignoring jshintrc configs

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -342,6 +342,8 @@ The latest dev versions are on github
 
 Next
     - auto close location list when leaving buffer. (millermedeiros)
+    - updates/fixes to existing checkers:
+        - javascript (millermedeiros)
 
 2.1.0
     - when the cursor is on a line containing an error, echo the

--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -13,7 +13,9 @@ if !exists("g:syntastic_javascript_jshint_conf")
 endif
 
 function! SyntaxCheckers_javascript_GetLocList()
-    let makeprg = 'jshint ' . shellescape(expand("%")) . ' --config ' . g:syntastic_javascript_jshint_conf
+    " node-jshint uses .jshintrc as config unless --config arg is present
+    let args = g:syntastic_javascript_jshint_conf? ' --config ' . g:syntastic_javascript_jshint_conf : ''
+    let makeprg = 'jshint ' . shellescape(expand("%")) . args
     let errorformat = '%ELine %l:%c,%Z\\s%#Reason: %m,%C%.%#,%f: line %l\, col %c\, %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'defaults': {'bufnr': bufnr('')} })
 endfunction


### PR DESCRIPTION
not sure if it was some change on node-jshint itself (not checking if config contains anything) or just the way the syntax checker pass configs... long story short, it's fixed.. it will read `.jshintrc` files unless you set your own configs..

(I have a global `.jshintrc` file that I use for most projects and sometimes I set local `.jshintrc` files as well..)
