### PR TITLE
fix small bug in s:Errors()

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -214,7 +214,7 @@ function! s:ErrorsForType(type)
 endfunction
 
 function! s:Errors()
-    return extend(s:ErrorsForType("E"))
+    return s:ErrorsForType("E")
 endfunction
 
 function! s:Warnings()


### PR DESCRIPTION
I just stumpled upon this small bug in s:Errors() function. I think this one just occurs when using the statusline flag of syntastic.
