### PR TITLE
Allow multiple filetypes, such as "c.doxygen" or "php.drupal".

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -199,7 +199,8 @@ detected, but not opened automatically. >
                                                         *'syntastic_mode_map'*
 Default: { "mode": "active",
            "active_filetypes": [],
-           "passive_filetypes": [] }
+           "passive_filetypes": [],
+           "AllowAutoChecking":|Funcref|}
 
 Use this option to fine tune when automatic syntax checking is done (or not
 done).
@@ -227,6 +228,9 @@ active and passive mode.
 
 If any of "mode", "active_filetypes", or "passive_filetypes" are not specified
 then they will default to their default value as above.
+
+The script defines the function AllowAutoChecking(), which returns 1 or 0
+depending on the current 'filetype'.
 
                                                   *'syntastic_quiet_warnings'*
 


### PR DESCRIPTION
This patch makes two small changes:
1. Add a `!` to the one function definition that lacks it, so that`
:unlet loaded_syntastic_plugin
:runtime plugin/syntastic.vim
`does not throw an error.
2. Replace `s:ModeMapAllowsAutoChecking()` with the [Dictionary-function](http://vimdoc.sourceforge.net/htmldoc/eval.html#Dictionary-function) `g:syntastic_mode_map.AllowAutoChecking()`.  This should not affect the behavior of the  script, but I think this is what Dictionary functions were invented for.

The big change in this patch is to rewrite the functions `s:CacheErrors()` and `s:ModeMapAllowsAutoChecking()` so that multiple filetypes are checked separately.
