### PR TITLE
A cleaner fix for wrapping makeprg's arguments that have spaces.

### DIFF
--- a/syntax_checkers/html.vim
+++ b/syntax_checkers/html.vim
@@ -62,11 +62,7 @@ endfunction
 function! SyntaxCheckers_html_GetLocList()
 
     let encopt = s:TidyEncOptByFenc()
-    if has('win32') || has('win64')
-      let makeprg='tidy '.encopt.' --new-blocklevel-tags "section, article, aside, hgroup, header, footer, nav, figure, figcaption" --new-inline-tags "video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist" --new-empty-tags "wbr, keygen" -e '.shellescape(expand("%"))
-    else
-      let makeprg="tidy ".encopt." --new-blocklevel-tags 'section, article, aside, hgroup, header, footer, nav, figure, figcaption' --new-inline-tags 'video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist' --new-empty-tags 'wbr, keygen' -e ".shellescape(expand('%'))." 2>&1"
-    endif
+    let makeprg="tidy ".encopt." --new-blocklevel-tags ".shellescape('section, article, aside, hgroup, header, footer, nav, figure, figcaption')." --new-inline-tags ".shellescape('video, audio, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist')." --new-empty-tags ".shellescape('wbr, keygen')." -e ".shellescape(expand('%'))." 2>&1"
     let errorformat='%Wline %l column %c - Warning: %m,%Eline %l column %c - Error: %m,%-G%.%#,%-G%.%#'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
Instead of using an if statement to set makeprg for win32/64, use shellescape() to properly escape arguments that have spaces.  

As mentioned in comments of previous commit, cmd.exe does not parse single quotes ' properly and requires arguments with spaces to be wrapped in double quotes (").  Wrapping each argument that has spaces with shellescape() resolves the problem without requiring an if statement.
