### PR TITLE
Use the default coding standard which phpcs is configured to use

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -21,7 +21,7 @@ endif
 
 "Support passing configuration directives to phpcs
 if !exists("g:syntastic_phpcs_conf")
-    let g:syntastic_phpcs_conf = "--standard=Zend"
+    let g:syntastic_phpcs_conf = ""
 endif
 
 if !exists("g:syntastic_phpcs_disable")


### PR DESCRIPTION
The current code for php overrides the configured default standard for phpcs.

It should not be necessary to define `g:syntastic_phpcs_conf` to prevent this tool's 'default' setting from taking precedence.

see http://pear.php.net/manual/en/package.php.php-codesniffer.config-options.php#package.php.php-codesniffer.config-options.php-codesniffer.default-standard

Edit: this reverts (deliberately) e3c2b95b94ec1573a4c7499d083b17558ad579cb
