### PR TITLE
new go syntax checker

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -460,6 +460,7 @@ endfunction
 "a:options can contain the following keys:
 "    'makeprg'
 "    'errorformat'
+"    'shellpipe'
 "
 "The corresponding options are set for the duration of the function call. They
 "are set with :let, so dont escape spaces.
@@ -482,6 +483,10 @@ function! SyntasticMake(options)
 
     if has_key(a:options, 'makeprg')
         let &makeprg = a:options['makeprg']
+    endif
+
+    if has_key(a:options, 'shellpipe')
+        let &shellpipe = a:options['shellpipe']
     endif
 
     if has_key(a:options, 'errorformat')

--- a/syntax_checkers/go.vim
+++ b/syntax_checkers/go.vim
@@ -1,7 +1,7 @@
 "============================================================================
 "File:        go.vim
 "Description: Syntax checking plugin for syntastic.vim
-"Maintainer:  Sam Nguyen <samxnguyen@gmail.com>
+"Maintainer:  Martin Grenfell <martin.grenfell at gmail dot com>
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
 "             it and/or modify it under the terms of the Do What The Fuck You
@@ -14,14 +14,23 @@ if exists("loaded_go_syntax_checker")
 endif
 let loaded_go_syntax_checker = 1
 
-"bail if the user doesnt have 6g installed
-if !executable("6g")
-    finish
-endif
+let s:supported_checkers = ["gofmt", "6g"]
 
-function! SyntaxCheckers_go_GetLocList()
-    let makeprg = '6g -o /dev/null %'
-    let errorformat = '%E%f:%l: %m'
-
-    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+function! s:load_checker(checker)
+    exec "runtime syntax_checkers/go/" . a:checker . ".vim"
 endfunction
+
+if exists("g:syntastic_go_checker")
+    if index(s:supported_checkers, g:syntastic_go_checker) != -1 && executable(g:syntastic_go_checker)
+        call s:load_checker(g:syntastic_go_checker)
+    else
+        echoerr "GO syntax not supported or not installed."
+    endif
+else
+    for checker in s:supported_checkers
+        if executable(checker)
+            call s:load_checker(checker)
+            break
+        endif
+    endfor
+endif

--- a/syntax_checkers/go/6g.vim
+++ b/syntax_checkers/go/6g.vim
@@ -1,0 +1,18 @@
+"============================================================================
+"File:        6g.vim
+"Description: Check go syntax by compiling current file with 6g
+"Maintainer:  Sam Nguyen <samxnguyen@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+function! SyntaxCheckers_go_GetLocList()
+    let makeprg = '6g -o /dev/null %'
+    let errorformat = '%E%f:%l: %m'
+
+    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+endfunction

--- a/syntax_checkers/go/gofmt.vim
+++ b/syntax_checkers/go/gofmt.vim
@@ -1,0 +1,26 @@
+"============================================================================
+"File:        gofmt.vim
+"Description: Check go syntax using gofmt
+"Maintainer:  Brandon Thomson <bt@brandonthomson.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+function! SyntaxCheckers_go_GetLocList()
+    let makeprg = 'gofmt %'
+
+    " If there are no syntax errors gofmt will write the formatted source to
+    " stdout which will make a big honking mess in the location list. So
+    " override the default shellpipe to get messages only from stderr. Also
+    " send stdout to /dev/null so the screen won't have to be :redraw'n
+    " whenever there are no errors)
+    let shellpipe = '1>/dev/null 2>'
+
+    let errorformat = '%E%f:%l:%c: %m'
+
+    return SyntasticMake({ 'makeprg': makeprg, 'shellpipe': shellpipe, 'errorformat': errorformat })
+endfunction


### PR DESCRIPTION
This adds a new syntax checker for go which uses the gofmt tool. I copied
support for multiple checkers from the javascript.vim.

To avoid making a mess I needed to change shellpipe during the make so
that is added as an option.

I think gofmt is a better default checker for go so I made it the first one
but I guess any existing users may also not want their setting to change.
I'm not sure if there is a good way around that.
