### PR TITLE
only run phpcs if the file has no syntax errors.

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -37,13 +37,14 @@ endfunction
 function! SyntaxCheckers_php_GetLocList()
 
     let errors = []
-    if !g:syntastic_phpcs_disable && executable("phpcs")
-        let errors = s:GetPHPCSErrors()
-    endif
 
     let makeprg = "php -l ".shellescape(expand('%'))
     let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l'
-    let errors = errors + SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+    let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+
+    if empty(errors) && !g:syntastic_phpcs_disable && executable("phpcs")
+        let errors = errors + s:GetPHPCSErrors()
+    endif
 
     call SyntasticHighlightErrors(errors, function('SyntaxCheckers_php_Term'))
 


### PR DESCRIPTION
running phpcs on a file which contains a parse error _may_ generate a huge
number of warnings from the phpcs library. 

You can see an example of what phpcs outputs in such cases here: https://gist.github.com/6c6535c3fc22c754ca6b

Therefore - don't run phpcs on files which have parse errors; don't freeze vim for minutes at a time when syntastic is already aware that the file is fundamentally borked
