### PR TITLE
Python syntax checker executable check uses a string, when it should use value of the variable

### DIFF
--- a/syntax_checkers/python.vim
+++ b/syntax_checkers/python.vim
@@ -20,7 +20,7 @@ endif
 let loaded_python_syntax_checker = 1
 
 "bail if the user doesnt have his favorite checker or flake8 or pyflakes installed
-if !exists('g:syntastic_python_checker') || !executable('g:syntastic_python_checker')
+if !exists('g:syntastic_python_checker') || !executable(g:syntastic_python_checker)
     if executable("flake8")
         let g:syntastic_python_checker = 'flake8'
     elseif executable("pyflakes")


### PR DESCRIPTION
The syntax checker currently does `executable('g:syntastic_python_checker')` but this actually checks if the literal string "g:syntastic_python_checker" is an executable, which is never true. This makes it so that if you attempt to force a python checker in your `vimrc` before syntastic is loaded, it always gets reset.

`executable` should use the actual variable value.
