### PR TITLE
Fix the error in the .c syntax checking and Python 3.x

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -145,7 +145,7 @@ function! syntastic#c#CheckPython()
     if executable('python')
         if !exists('s:python_flags')
             let s:python_flags = system('python -c ''from distutils import '
-                        \ . 'sysconfig; print sysconfig.get_python_inc()''')
+                        \ . 'sysconfig; import sys; sys.stdout.write(sysconfig.get_python_inc())''')
             let s:python_flags = substitute(s:python_flags, "\n", '', '')
             let s:python_flags = ' -I' . s:python_flags
         endif


### PR DESCRIPTION
When 'python' executable is Python 3.x, error occurs.

```
% python --version
Python 3.2.2
```

Type the 'vim a.c' and write the following:

```
#include <Python.h>
```

And syntax checking by save the file (type the :w).
