### PR TITLE
fix: javascript jshint config

### DIFF
--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -14,7 +14,7 @@ endif
 
 function! SyntaxCheckers_javascript_GetLocList()
     " node-jshint uses .jshintrc as config unless --config arg is present
-    let args = g:syntastic_javascript_jshint_conf != '' ? ' --config ' . g:syntastic_javascript_jshint_conf : ''
+    let args = !empty(g:syntastic_javascript_jshint_conf) ? ' --config ' . g:syntastic_javascript_jshint_conf : ''
     let makeprg = 'jshint ' . shellescape(expand("%")) . args
     let errorformat = '%ELine %l:%c,%Z\\s%#Reason: %m,%C%.%#,%f: line %l\, col %c\, %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'defaults': {'bufnr': bufnr('')} })


### PR DESCRIPTION
This pull request contains a fix for pulling in a custom config.

The ternary expression just checks for string. Because vimscript coerces strings to numbers it will be false even if the string is not empty. The fix just involves using the built-in `empty()` function. Tested and working fine now.
