### PR TITLE
puppet: enable --storeconfigs on 2.7

### DIFF
--- a/syntax_checkers/puppet.vim
+++ b/syntax_checkers/puppet.vim
@@ -32,7 +32,8 @@ function! SyntaxCheckers_puppet_GetLocList()
     if s:puppetVersion[0] >= '2' && s:puppetVersion[1] >= '7'
         let makeprg = 'puppet parser validate ' .
                     \ shellescape(expand('%')) .
-                    \ ' --color=false'
+                    \ ' --color=false' .
+                    \ ' --storeconfigs'
 
         "add --ignoreimport for versions < 2.7.10
         if s:puppetVersion[2] < '10'


### PR DESCRIPTION
without --storeconfigs it's going to complain alot if you have any exported
resources in your manifests.

on 2.6 --storeconfigs complains if you don't have activerecord, so leaving it enabled only for 2.7.
