### PR TITLE
php: fix lint if display_errors is off

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -38,7 +38,7 @@ function! SyntaxCheckers_php_GetLocList()
 
     let errors = []
 
-    let makeprg = "php -l ".shellescape(expand('%'))
+    let makeprg = "php -l -d display_errors=1 ".shellescape(expand('%'))
     let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l'
     let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
display_errors might be turned of for php globally. In this case the
output of php -l does not contain the errors messages. Using this option
will turn the option on for the single call.
