### PR TITLE
Small NASM syntax checker fix

### DIFF
--- a/syntax_checkers/nasm.vim
+++ b/syntax_checkers/nasm.vim
@@ -25,7 +25,8 @@ function! SyntaxCheckers_nasm_GetLocList()
     else
         let outfile="/dev/null"
     endif
-    let makeprg = "nasm -X gnu -f elf -o " . outfile . " " . shellescape(expand("%"))
+    let wd = shellescape(expand("%:p:h") . "/")
+    let makeprg = "nasm -X gnu -f elf -I " . wd . " -o " . outfile . " " . shellescape(expand("%"))
     let errorformat = '%f:%l: %t%*[^:]: %m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
There was a small problem with the previous pull request; NASM apparently uses the current working directory and not the directory of the file being compiled when looking for stuff to `%include`. This commit fixes this issue, and all should be good.
