### PR TITLE
php is now forced to display parse errors

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -38,7 +38,7 @@ function! SyntaxCheckers_php_GetLocList()
 
     let errors = []
 
-    let makeprg = "php -l ".shellescape(expand('%'))
+    let makeprg = "php -l -d error_reporting=E_PARSE -d display_errors=1 ".shellescape(expand('%'))
     let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l'
     let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
Production PHP environments typically set `display_errors` and `error_reporting` INI settings to quiet levels. Doing so suppresses parse error details, causing syntastic checks to succeed always.
