### PR TITLE
Next/Previous Error Commands

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -125,6 +125,16 @@ Syntastic's own location list.
 When errors have been detected, use this command to pop up the |location-list|
 and display the error messages.
 
+:NextError                                                  *:SyntasticErrors*
+
+Go to the next error in the file relative to current position in the file.
+Does not loop to the beginning once the end of the file has been reached.
+
+:PreviousError                                              *:SyntasticErrors*
+
+Go to the previous error in the file relative to current position in the file.
+Does not loop to the end once the beginning of the file has been reached.
+
 
 :SyntasticToggleMode                                    *:SyntasticToggleMode*
 

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -88,6 +88,8 @@ endif
 command! SyntasticToggleMode call s:ToggleMode()
 command! SyntasticCheck call s:UpdateErrors(0) <bar> redraw!
 command! Errors call s:ShowLocList()
+command! NextError call s:JumpToError(0)
+command! PreviousError call s:JumpToError(1)
 
 highlight link SyntasticError SpellBad
 highlight link SyntasticWarning SpellCap
@@ -351,6 +353,21 @@ function! s:ShowLocList()
         if num != winnr()
             wincmd p
         endif
+    endif
+endfunction
+
+"jump to next/previous error depending on reverse argument
+"doesn't loop back over the buffer after reaching the end.
+function! s:JumpToError(reverse)
+    if s:BufHasErrorsOrWarningsToDisplay()
+        let current_line = line(".")
+        let loc_list = a:reverse ? reverse(s:LocList()) : s:LocList()
+        for i in loc_list
+            if (current_line < i['lnum'] && !a:reverse) || (current_line > i['lnum'] && a:reverse)
+                exec ":" . i['lnum']
+                break
+            endif
+        endfor
     endif
 endfunction
 


### PR DESCRIPTION
I added a couple commands to move to the next & previous errors in the buffer. I'm new to VimL, so, the code isn't too pretty, but I thought some people might find it useful (scratched my own itch, at least).

Let me know if you see a better way to do it! And if my code is abysmal, just consider this a feature request! :D
