### PR TITLE
Fix the errorformat in pylint.vim

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -9,6 +9,6 @@ function! SyntaxCheckers_python_GetLocList()
                 \ shellescape(expand('%')) .
                 \ ' \| sed ''s_: \[[RC]_: \[W_''' .
                 \ ' \| sed ''s_: \[[F]_:\ \[E_'''
-    let errorformat = '%f:%l: [%t%n] %m,%-GNo config%m'
+    let errorformat = '%f:%l: [%t%n%[%^]]%#] %m,%-GNo config%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
For [Issue #193](https://github.com/scrooloose/syntastic/issues/193)

P.S. I'm new to github and vim scripting, so if you see a better way to do it, just point it out. :)
