### PR TITLE
Fix for pylint errorformat string

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -9,6 +9,6 @@ function! SyntaxCheckers_python_GetLocList()
                 \ shellescape(expand('%')) .
                 \ ' \| sed ''s_: \[[RC]_: \[W_''' .
                 \ ' \| sed ''s_: \[[F]_:\ \[E_'''
-    let errorformat = '%f:%l: [%t%n] %m,%-GNo config%m'
+    let errorformat = '%f:%l: [%t%n%.%#] %m,%f:%l: [%t%.%#] %m,%Z,%-GNo config%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
Used the error format string from sashahart/pylint.vim which seems
to be much more comprehensive.
