### PR TITLE
Fix custom compiler options handling for C/C++

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -55,17 +55,11 @@ endfunction
 
 " get the gcc include directory argument depending on the default
 " includes and the optional user-defined 'g:syntastic_c_include_dirs'
-function! syntastic#c#GetIncludeDirs(cpp)
+function! syntastic#c#GetIncludeDirs(filetype)
     let include_dirs = copy(s:default_includes)
 
-    if a:cpp == 1
-        if exists('g:syntastic_cpp_include_dirs')
-            call extend(include_dirs, g:syntastic_cpp_include_dirs)
-        endif
-    else
-        if exists('g:syntastic_c_include_dirs')
-            call extend(include_dirs, g:syntastic_c_include_dirs)
-        endif
+    if exists('g:syntastic_'.a:filetype.'_include_dirs')
+        call extend(include_dirs, g:syntastic_{a:filetype}_include_dirs)
     endif
 
     return join(map(s:Unique(include_dirs), '"-I" . v:val'), ' ')

--- a/syntax_checkers/c.vim
+++ b/syntax_checkers/c.vim
@@ -79,13 +79,13 @@ function! SyntaxCheckers_c_GetLocList()
     let makeprg .= g:syntastic_c_compiler_options
 
     let makeprg .= ' '.shellescape(expand('%')).
-               \ ' '.syntastic#c#GetIncludeDirs(0)
+               \ ' '.syntastic#c#GetIncludeDirs('c')
 
     " determine whether to parse header files as well
     if expand('%') =~? '.h$'
         if exists('g:syntastic_c_check_header')
             let makeprg = 'gcc -c '.shellescape(expand('%')).
-                        \ ' '.syntastic#c#GetIncludeDirs(0)
+                        \ ' '.syntastic#c#GetIncludeDirs('c')
         else
             return []
         endif

--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -73,12 +73,12 @@ function! SyntaxCheckers_cpp_GetLocList()
     endif
 
     let makeprg .= ' ' . shellescape(expand('%')) .
-                \ ' ' . syntastic#c#GetIncludeDirs(1)
+                \ ' ' . syntastic#c#GetIncludeDirs('cpp')
 
     if expand('%') =~? '\%(.h\|.hpp\|.hh\)$'
         if exists('g:syntastic_cpp_check_header')
             let makeprg = 'g++ -c '.shellescape(expand('%')).
-                        \ ' ' . syntastic#c#GetIncludeDirs(1)
+                        \ ' ' . syntastic#c#GetIncludeDirs('cpp')
         else
             return []
         endif


### PR DESCRIPTION
Hi,

these commits should fix the usage of the compiler options `g:syntastic_c_compiler_options` and `g:syntastic_cpp_compiler_options`.

Cheers,
Gregor
