### PR TITLE
Fix pylint parsing

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -9,6 +9,6 @@ function! SyntaxCheckers_python_GetLocList()
                 \ shellescape(expand('%')) .
                 \ ' \| sed ''s_: \[[RC]_: \[W_''' .
                 \ ' \| sed ''s_: \[[F]_:\ \[E_'''
-    let errorformat = '%f:%l: [%t%n] %m,%-GNo config%m'
+    let errorformat = '%f:%l: [%t%n%.%#] %m,%-GNo config%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
My pylint output looks like this:

pypy/objspace/std/test/test_setobject.py:285: [E0602, AppTestAppSetTest.test_remove] Undefined variable 'raises'

I've added a bit of pattern to the errorformat (%.%#) to skip over the ", <functionname>" bit of the error message. Without it, syntastic fails silently and does nothing.
