### PR TITLE
redirect pylint stderr

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -7,7 +7,7 @@
 function! SyntaxCheckers_python_GetLocList()
     let makeprg = 'pylint -f parseable -r n -i y ' .
                 \ shellescape(expand('%')) .
-                \ ' \| sed ''s_: \[[RC]_: \[W_''' .
+                \ ' \|& sed ''s_: \[[RC]_: \[W_''' .
                 \ ' \| sed ''s_: \[[F]_:\ \[E_'''
     let errorformat = '%f:%l: [%t%n%.%#] %m,%-GNo config%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
prevent stderr from messing up the terminal, in the (usual) case of no pylintrc found
