### PR TITLE
Safely fetch 'col' key from error item, it may not exist.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -374,7 +374,7 @@ function! s:HightlightErrors()
             let force_callback = has_key(item, 'force_highlight_callback') && item['force_highlight_callback']
 
             let group = item['type'] == 'E' ? 'SyntasticError' : 'SyntasticWarning'
-            if item['col'] && !force_callback
+            if get( item, 'col' ) && !force_callback
                 let lastcol = col([item['lnum'], '$'])
                 let lcol = min([lastcol, item['col']])
                 call matchadd(group, '\%'.item['lnum'].'l\%'.lcol.'c')


### PR DESCRIPTION
Since commit 892cc2, errors appeared on screen for example when checking shell scripts.
