### PR TITLE
Fixes #202 - redict stderr in a way that doesn't break on versions of bash <4.0

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -7,7 +7,7 @@
 function! SyntaxCheckers_python_GetLocList()
     let makeprg = 'pylint '.g:syntastic_python_checker_args.' -f parseable -r n -i y ' .
                 \ shellescape(expand('%')) .
-                \ ' \|& sed ''s_: \[[RC]_: \[W_''' .
+                \ ' 2>&1 \| sed ''s_: \[[RC]_: \[W_''' .
                 \ ' \| sed ''s_: \[[F]_:\ \[E_'''
     let errorformat = '%f:%l: [%t%n%.%#] %m,%f:%l: [%t%.%#] %m,%Z,%-GNo config%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
The syntax `|&` for redirecting both stdout and stderr into a pipe was only introduced in Bash 4.0.

Older versions are still in widespread use; for instance, even the latest versions of OS X only ship with Bash 3.2
