### PR TITLE
Only keep "valid" entries in the error count.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -229,14 +229,14 @@ endfunction
 
 function! s:Errors()
     if !exists("b:syntastic_errors")
-        let b:syntastic_errors = s:FilterLocList({'type': "E"})
+        let b:syntastic_errors = s:FilterLocList({'type': "E", 'valid': 1})
     endif
     return b:syntastic_errors
 endfunction
 
 function! s:Warnings()
     if !exists("b:syntastic_warnings")
-        let b:syntastic_warnings = s:FilterLocList({'type': "W"})
+        let b:syntastic_warnings = s:FilterLocList({'type': "W", 'valid': 1})
     endif
     return b:syntastic_warnings
 endfunction


### PR DESCRIPTION
The location list returned by getloclist() may contain entries that are not errorformat matches. By "definition", (see :help getqflist), matched lines have the attribute "valid": 1 set, so only keep those lines in error/warning list to avoid erroneous counts and strange behaviors.

Signed-off-by: Florent Bruneau florent.bruneau@intersec.com
