### PR TITLE
Only keep "valid" entries in the error count.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -185,6 +185,8 @@ function! s:CacheErrors()
         for ft in split(fts, '\.')
             if s:Checkable(ft)
                 let errors = SyntaxCheckers_{ft}_GetLocList()
+                "keep only lines that effectively match an error/warning
+                let errors = s:FilterLocList({'valid': 1}, errors)
                 "make errors have type "E" by default
                 call SyntasticAddToErrors(errors, {'type': 'E'})
                 call extend(s:LocList(), errors)


### PR DESCRIPTION
The location list returned by getloclist() may contain entries that are
not errorformat matches. By "definition", (see :help getqflist), matched
lines have the attribute "valid": 1 set, so only keep those lines in
error/warning list to avoid erroneous counts and strange behaviors.
