### PR TITLE
Build all files with go build

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -10,7 +10,7 @@
 "
 "============================================================================
 function! SyntaxCheckers_go_GetLocList()
-    let makeprg = 'go build -o /dev/null %'
+    let makeprg = 'go build -o /dev/null'
     let errorformat = '%f:%l:%c:%m,%f:%l%m,%-G#%.%#'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
Addresses comments in #191 regarding building of multi-file projects. Actually works quite elegantly too as you can jump between the files with the quickfix window.
