### PR TITLE
flake8: don't clobber the text with Syntax Error

### DIFF
--- a/syntax_checkers/python/flake8.vim
+++ b/syntax_checkers/python/flake8.vim
@@ -6,9 +6,6 @@
 "
 "============================================================================
 function! SyntaxCheckers_python_GetHighlightRegex(i)
-    if a:i['type'] ==# 'E'
-        let a:i['text'] = "Syntax error"
-    endif
     if match(a:i['text'], 'is assigned to but never used') > -1
                 \ || match(a:i['text'], 'imported but unused') > -1
                 \ || match(a:i['text'], 'undefined name') > -1


### PR DESCRIPTION
It hides the actual warning/error from flake8 which isn't desirable as it means instead of saying Import not used, you get Syntax Error, which it isn't.
