### PR TITLE
PHP error not parsing

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -41,7 +41,7 @@ function! SyntaxCheckers_php_GetLocList()
     let errors = []
 
     let makeprg = "php -l -d error_reporting=E_ALL -d display_errors=0 -d error_log='' ".shellescape(expand('%'))
-    let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l'
+    let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l,PHP Parse %trror: %m in %f on line %l'
     let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 
     if empty(errors) && !g:syntastic_phpcs_disable && executable("phpcs")


### PR DESCRIPTION
I run a `php -l` manually (copying all the options out of php.vim) and get this output

```
PHP Parse error:  parse error in order.php on line 32
Errors parsing order.php
```

But in my window it's not showing any inline errors, and when I pop open my errors buffer with `:Errors`

It shows this 

![Problem Example](http://i40.tinypic.com/34ovep3.png)

PHP Version (Default OSX Lion)

```
PHP 5.3.8 with Suhosin-Patch (cli) (built: Nov 15 2011 15:33:15) 
Copyright (c) 1997-2011 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2011 Zend Technologies
```
