### PR TITLE
Fall-back on highlighting the entire line.

### DIFF
--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -69,7 +69,7 @@ if exists('loaded_cpp_syntax_checker')
 endif
 let loaded_cpp_syntax_checker = 1
 
-if !executable('g++')
+if !executable('c++')
     finish
 endif
 
@@ -81,7 +81,7 @@ if !exists('g:syntastic_cpp_config_file')
 endif
 
 function! SyntaxCheckers_cpp_GetLocList()
-    let makeprg = 'g++ -fsyntax-only '
+    let makeprg = 'c++ -fsyntax-only '
     let errorformat =  '%-G%f:%s:,%f:%l:%c: %trror: %m,%f:%l:%c: %tarning: '.
                 \ '%m,%f:%l:%c: %m,%f:%l: %trror: %m,%f:%l: %tarning: %m,'.
                 \ '%f:%l: %m'
@@ -99,7 +99,7 @@ function! SyntaxCheckers_cpp_GetLocList()
 
     if expand('%') =~? '\%(.h\|.hpp\|.hh\)$'
         if exists('g:syntastic_cpp_check_header')
-            let makeprg = 'g++ -c '.shellescape(expand('%')).
+            let makeprg = 'c++ -c '.shellescape(expand('%')).
                         \ ' ' . syntastic#c#GetIncludeDirs('cpp')
         else
             return []

--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -9,8 +9,15 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
+"bail if the user doesnt have go installed
+if !executable("go")
+    finish
+endif
+
+let s:check_file = expand('<sfile>:p:h') . '/go_check_file.sh'
+
 function! SyntaxCheckers_go_GetLocList()
-    let makeprg = 'go build -o /dev/null'
+    let makeprg = s:check_file . ' '. shellescape(expand('%:p'))
     let errorformat = '%f:%l:%c:%m,%f:%l%m,%-G#%.%#'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })

--- a/syntax_checkers/go/go_check_file.sh
+++ b/syntax_checkers/go/go_check_file.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This is necessary
+cd "`dirname $1`"
+go build -o /dev/null ./ 2>&1 | fgrep "`basename $1`:"


### PR DESCRIPTION
If column information isn't available and a language specific regex
highlighter isn't defined, fall-back on highlighting the entire line.
