### PR TITLE
Remove some unnecessary win64 checks.

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -128,7 +128,7 @@ function! syntastic#c#SearchHeaders()
     " search included headers
     for hfile in files
         if hfile != ''
-            let filename = expand('%:p:h') . ((has('win32') || has('win64')) ?
+            let filename = expand('%:p:h') . (has('win32') ?
                         \ '\' : '/') . hfile
             try
                 let lines = readfile(filename, '', 100)

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -17,7 +17,7 @@ if exists("g:loaded_syntastic_plugin")
 endif
 let g:loaded_syntastic_plugin = 1
 
-let s:running_windows = has("win16") || has("win32") || has("win64")
+let s:running_windows = has("win16") || has("win32")
 
 if !s:running_windows
     let s:uname = system('uname')

--- a/syntax_checkers/eruby.vim
+++ b/syntax_checkers/eruby.vim
@@ -20,7 +20,7 @@ if !executable("ruby") || !executable("cat")
 endif
 
 function! SyntaxCheckers_eruby_GetLocList()
-    if has('win32') || has('win64')
+    if has('win32')
         let makeprg='sed "s/<\%=/<\%/g" '. shellescape(expand("%")) . ' \| ruby -e "require \"erb\"; puts ERB.new(ARGF.read, nil, \"-\").src" \| ruby -c'
     else
         let makeprg='sed "s/<\%=/<\%/g" '. shellescape(expand("%")) . ' \| RUBYOPT= ruby -e "require \"erb\"; puts ERB.new(ARGF.read, nil, \"-\").src" \| RUBYOPT= ruby -c'

--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -11,7 +11,7 @@
 "============================================================================
 function! SyntaxCheckers_ruby_GetLocList()
     " we cannot set RUBYOPT on windows like that
-    if has('win32') || has('win64')
+    if has('win32')
         let makeprg = 'ruby -W1 -T1 -c '.shellescape(expand('%'))
     else
         let makeprg = 'RUBYOPT= ruby -W1 -c '.shellescape(expand('%'))


### PR DESCRIPTION
has('win32') is always true on Win64.

This is not only true for vim, but also a convention of windows programming. See [this page](http://msdn.microsoft.com/en-us/library/b0084kay.aspx), note the `_WIN32` and `_WIN64` macro.
