### PR TITLE
Fix for Loadchecker when using multiple filetypes

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -426,7 +426,9 @@ endfunction
 "load the chosen checker for the current filetype - useful for filetypes like
 "javascript that have more than one syntax checker
 function! s:LoadChecker(checker)
-    exec "runtime syntax_checkers/" . &ft . "/" . a:checker . ".vim"
+    for aft in split(&ft, '\.')
+        exec "runtime syntax_checkers/" . aft . "/" . a:checker . ".vim"
+    endfor
 endfunction
 
 "return a string representing the state of buffer according to


### PR DESCRIPTION
When using multiple filetypes, like python.django, LoadChecker tried to load syntax_checkers/python.django/flake8.vim instead of syntax_checkers/python/flake8.vim, rendering syntastic unusable for this kind of cases.
