### PR TITLE
Only highlight the first occurrence of a term.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -385,7 +385,7 @@ function! s:HightlightErrors()
                 if exists("*SyntaxCheckers_". ft ."_GetHighlightRegex")
                     let term = SyntaxCheckers_{ft}_GetHighlightRegex(item)
                     if len(term) > 0
-                        call matchadd(group, '\%' . item['lnum'] . 'l' . term)
+                        call matchadd(group, '^.\{-}\zs\%' . item['lnum'] . 'l' . term)
                     endif
                 endif
             endif


### PR DESCRIPTION
This commit will ensure that only the first term is highlighted (for an error/warning which is lacking column information).

Take the following Python code sample:

```
some_author = Author.objects.get(...)
books = some_author.books.all()
# The variable 'books' isn't used.
```

As syntastic currently performs highlighting, both occurrences of the word 'books' will be highlighted -- whereas only the first occurence should be highlighted.

This solution isn't perfect, take the following sample:

```
some_author.books.some_method(books)
```

Here, the 'books' property will be highlighted, rather than the passed variable. However, in my opinion, this is better than highlighting both.

Of course, the real solution is to have column information for every error/warning that needs to highlight a term ;-).
