### PR TITLE
Workaround bug in vim related to E855

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -354,7 +354,7 @@ endfunction
 
 "display the cached errors for this buf in the location list
 function! s:ShowLocList()
-    if !empty(s:LocList())
+    if !empty(getloclist(0))
         let num = winnr()
         exec "lopen " . g:syntastic_loc_list_height
         if num != winnr()


### PR DESCRIPTION
There is a bug in current Vim (7.3.515) and older triggered by
autocommands. Vim patch 7.3.449 (Autocommands caused command to abort)
tried to fix it, but it's either wrong or incomplete and doesn't work.

Example case which trigger this bug is trying to do :lclose in autocommand
executed while closing location-list, which happens because of this:

```
autocmd BufWinLeave * if empty(&bt) | lclose | endif
```

Too see this bug it's enough to set

```
let g:syntastic_auto_loc_list=1
```

then open file with syntax error and try to :wq
If there no other tabs (:tabnew), then you'll get error:

```
E855 Autocommands caused command to abort
```

but if there are some tabs then vim will crash with segfault.
Vim versions before 7.3.449 behave differently without tabs and all crash
with tabs.

First issue is &bt inside BufWinLeave may be different from the buffer
being unloaded (this is documented behaviour for BufWinLeave), so it
should be replaced with: getbufvar(0+expand('<abuf>'), '&bt').

This is bug in syntastic, but fixing it solve overall issue only
partially - now bug doesn't triggered on :lclose and :q inside
location-list window, but :q inside main file window (when location-list
open) still result in same E855 or segfault, which is bug in Vim.

To workaround bug in Vim I've change logic to close location-list window:
instead of closing it on BufWinLeave, it's closed on BufEnter in
location-list window if it's only buffer in current window.
