### PR TITLE
Disable sass cache creation

### DIFF
--- a/syntax_checkers/sass.vim
+++ b/syntax_checkers/sass.vim
@@ -26,7 +26,7 @@ if executable("compass")
 endif
 
 function! SyntaxCheckers_sass_GetLocList()
-    let makeprg='sass '.s:imports.' --check '.shellescape(expand('%'))
+    let makeprg='sass --no-cache '.s:imports.' --check '.shellescape(expand('%'))
     let errorformat = '%ESyntax %trror:%m,%C        on line %l of %f,%Z%.%#'
     let errorformat .= ',%Wwarning on line %l:,%Z%m,Syntax %trror on line %l: %m'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
The sass cache creation causes .sass-cache directories to be scattered
throughout a project.

Fixes #258
