### PR TITLE
Fix 'E776: No location list' on re-opening file

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -347,7 +347,7 @@ endfunction
 
 "display the cached errors for this buf in the location list
 function! s:ShowLocList()
-    if !empty(s:LocList())
+    if !empty(getloclist(0))
         let num = winnr()
         exec "lopen " . g:syntastic_loc_list_height
         if num != winnr()


### PR DESCRIPTION
Open two files in tabs, write one of them to get syntax errors in
location-list, :q from that file/tab, then open that file again
with :tabnew - you'll see E776 because after :q buffer wasn't deleted,
and so b:syntastic_loclist still contain old errors, while location-list
(associated with window, not buffer) was deleted and thus :lopen fails.
