### PR TITLE
Fix: efm_perl missed some error messages

### DIFF
--- a/syntax_checkers/efm_perl.pl
+++ b/syntax_checkers/efm_perl.pl
@@ -94,7 +94,7 @@ foreach my $line (@lines) {
     chomp($line);
     my ($file, $lineno, $message, $rest);
 
-    if ($line =~ /^(.*)\sat\s(.*)\sline\s(\d+)(\.|,\snear\s\".*\")$/) {
+    if ($line =~ /^(.*)\sat\s(.*)\sline\s(\d+)(.*)$/) {
 
 	($message, $file, $lineno, $rest) = ($1, $2, $3, $4);
 	$errors++;


### PR DESCRIPTION
First example:

```
$ echo -e 'if (0)\nsome();\n}' | perl -c -
Semicolon seems to be missing at - line 1.
syntax error at - line 2, near ")
some"
Unmatched right curly bracket at - line 3, at end of line
- had compilation errors.

$ echo -e 'if (0)\nsome();\n}' | perl syntax_checkers/efm_perl.pl -c -
-:1:Semicolon seems to be missing
```

Second example:

```
$ echo -e 'if (0)' | perl -c -
syntax error at - line 1, at EOF
- had compilation errors.

$ echo -e 'if (0)' | perl syntax_checkers/efm_perl.pl -c -
```
