### PR TITLE
support directory-level include directories

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -62,6 +62,22 @@ function! syntastic#c#GetIncludeDirs(filetype)
         call extend(include_dirs, g:syntastic_{a:filetype}_include_dirs)
     endif
 
+    let directory = fnamemodify(bufname("%"), ":p:h")
+    if filereadable(directory.'/.syntastic_'.a:filetype.'_include_dirs')
+        let local_include_dirs = readfile(directory.'/.syntastic_'.a:filetype.'_include_dirs')
+        let relative_dirs = []
+
+        for dir in local_include_dirs
+            if dir =~ "^\\..*$"
+                let dir = directory.'/'.dir
+            endif
+
+            call add(relative_dirs, dir)
+        endfor
+
+        call extend(include_dirs, relative_dirs)
+    endif
+
     return join(map(s:Unique(include_dirs), '"-I" . v:val'), ' ')
 endfunction
 


### PR DESCRIPTION
Added some code to autoload/syntastic/c.vim that searches for a local .syntastic_[filetype]_include_dirs file containing an additional, directory-specific include directory to be used.

This is the first time I write a VIM script, so I expect you might want to either clean up/tidy/optimize my version.
