### PR TITLE
Enable pass arguments to puppet-lint

### DIFF
--- a/syntax_checkers/puppet.vim
+++ b/syntax_checkers/puppet.vim
@@ -48,7 +48,11 @@ if !(s:lintVersion[0] >= '0' && s:lintVersion[1] >= '1' && s:lintVersion[2] >= '
 endif
 
 function! s:getPuppetLintErrors()
-    let makeprg = 'puppet-lint --log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}" '.shellescape(expand('%'))
+    if !exists("g:syntastic_puppet_lint_arguments")
+        let g:syntastic_puppet_lint_arguments = ''
+    endif
+
+    let makeprg = 'puppet-lint --log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}" '.g:syntastic_puppet_lint_arguments.shellescape(expand('%'))
     let errorformat = '%t%*[a-zA-Z] %m at %f:%l'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype': 'Style' })
 endfunction


### PR DESCRIPTION
Some users might want to disable some checks for puppet-lint if they do
not intend to follow all of the style recommendations. There is
currently no way of doing that.

By adding a global variable synstastic_puppet_lint_arguments, one can
now set arguments to pass to puppet-lint via .vimrc.

Signed-off-by: Gabriel Filion lelutin@gmail.com
