### PR TITLE
Fix merge error in the perl checker

### DIFF
--- a/syntax_checkers/efm_perl.pl
+++ b/syntax_checkers/efm_perl.pl
@@ -114,7 +114,7 @@ foreach my $line (@lines) {
     chomp($line);
     my ($file, $lineno, $message, $rest, $severity);
 
-    if ($line =~ /^(.*)\sat\s(.*)\sline\s(\d+)(.*)$/) {
+    if ($line =~ /^([EW]):(.*)\sat\s(.*)\sline\s(\d+)(.*)$/) {
 	($severity, $message, $file, $lineno, $rest) = ($1, $2, $3, $4, $5);
 	$errors++;
 	$message .= $rest if ($rest =~ s/^,//);


### PR DESCRIPTION
Looks like the conflict my last commits had didn't quite merge in correctly. This should fix it and allow the Perl checker to work again.
