### PR TITLE
Global option for Cuda arch flag

### DIFF
--- a/syntax_checkers/cuda.vim
+++ b/syntax_checkers/cuda.vim
@@ -39,7 +39,7 @@ function! SyntaxCheckers_cuda_GetLocList()
 
     if expand('%') =~? '\%(.h\|.hpp\|.cuh\)$'
         if exists('g:syntastic_cuda_check_header')
-            let makeprg = 'echo > .syntastic_dummy.cu ; nvcc --cuda -O0 -I . .syntastic_dummy.cu -Xcompiler -fsyntax-only -include '.shellescape(expand('%')).' -o /dev/null'
+            let makeprg = 'echo > .syntastic_dummy.cu ; nvcc '.arch_flag.' --cuda -O0 -I . .syntastic_dummy.cu -Xcompiler -fsyntax-only -include '.shellescape(expand('%')).' -o /dev/null'
         else
             return []
         endif


### PR DESCRIPTION
Cuda programs may produce different errors depending on the architecture of the
target hardware. The canonical example and reason for writing this patch, is the
lack of support for double precision numbers on older hardware. By default, nvcc
and thus syntastic, defaults to the most basic architecture. This can produce
false errors if the developer intends to compile for newer hardware and use
newer features.

Not defining g:syntastic_cuda_arch preserves this behavior. Otherwise the user
is expected to set it a valid arch flag, as listed by `nvcc --help`.

Example:

```
let g:syntastic_cuda_arch = "sm_20"
```

This could be generalized, but I don't know how common of a problem it really is. Cuda might be a special case.
