### PR TITLE
Display original pylint error code so users might easily identify specific errors

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -7,8 +7,8 @@
 function! SyntaxCheckers_python_GetLocList()
     let makeprg = 'pylint '.g:syntastic_python_checker_args.' -f parseable -r n -i y ' .
                 \ shellescape(expand('%')) .
-                \ ' 2>&1 \| sed ''s_: \[[RC]_: \[W_''' .
-                \ ' \| sed ''s_: \[[F]_:\ \[E_'''
-    let errorformat = '%f:%l: [%t%n%.%#] %m,%f:%l: [%t%.%#] %m,%Z,%-GNo config%m'
+                \ ' 2>&1 \| sed ''s_: \[\([RCW]\)_: \[W] \[\1_''' .
+                \ ' \| sed ''s_: \[\([FE]\)_:\ \[E] \[\1_'''
+    let errorformat = '%f:%l: [%t] %m,%Z,%-GNo config %m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
The current pylint checker alters incoming messages from pylint, converting identifying information including the message's class ('R' for 'refactor', 'C' for 'convention', 'W' for 'warning', 'E' for 'error', and 'F' for 'Fatal') into something understandable by syntastic.  This destroys a bit of useful information in that the error code's class is essential for both looking up errors as well as disabling specific error codes in one's ~/.pylintrc.

Since pylint is so exceptionally noisy, it's a common concern for people to disable specific messages; this request's changes alter syntastic's display of pylint's output such that it displays the original message code as well as the error message.
