### PR TITLE
Fix js-yaml (CLI) installation instructions

### DIFF
--- a/syntax_checkers/yaml.vim
+++ b/syntax_checkers/yaml.vim
@@ -9,7 +9,7 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "
-"Installation: $ npm install -g js-yaml.bin
+"Installation: $ npm install -g js-yaml
 "
 "============================================================================
 if exists("loaded_yaml_syntax_checker")


### PR DESCRIPTION
Since js-yaml 1.0.0 CLI executable is bundled into main module, so js-yaml.bin become deprecated and will be removed.
