### PR TITLE
Support reading C/C++ including path from EditorConfig files.

### DIFF
--- a/syntax_checkers/c.vim
+++ b/syntax_checkers/c.vim
@@ -126,6 +126,7 @@ function! SyntaxCheckers_c_GetLocList()
 
     " add optional config file parameters
     let makeprg .= ' '.syntastic#c#ReadConfig(g:syntastic_c_config_file)
+    let makeprg .= ' ' . syntastic#c#ReadEditorConfigIncludePath()
 
     " process makeprg
     let errors = SyntasticMake({ 'makeprg': makeprg,

--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -114,6 +114,7 @@ function! SyntaxCheckers_cpp_GetLocList()
 
     " add optional config file parameters
     let makeprg .= ' ' . syntastic#c#ReadConfig(g:syntastic_cpp_config_file)
+    let makeprg .= ' ' . syntastic#c#ReadEditorConfigIncludePath()
 
     " process makeprg
     let errors = SyntasticMake({ 'makeprg': makeprg,


### PR DESCRIPTION
Add discussed in #220 and #215, 

> As long as there is no global architecture for configuration files for syntax checkers this one has to do the trick I guess. Comments and further suggestions are appreciated anyways.

This pull request will support [EditorConfig](http://editorconfig.org) as the global architecture of configuration for editors and IDEs, for the same purpose as #220.

EditorConfig has been used by [many projects](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig), and is supported on [many editors/IDEs](http://editorconfig.org/#download), so I believe it is time to include this feature in syntastic.

This pull request read a property called `c_include_path` in the `.editorconfig` files, which [will be added in the official standard in the future](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties). This feature also depends on the [EditorConfig Vim plugin](https://github.com/editorconfig/editorconfig-vim), and takes use of its [hook mechanism](https://github.com/editorconfig/editorconfig-vim/blob/682f9ff1ae0ebba1edfafb6d5d1a1fd190ddfcda/doc/editorconfig.txt#L143), which was first introduced in editorconfig/editorconfig#45. 

Wish this could be included. Thanks!
