### PR TITLE
Let user configure errorformat string in c/cpp syntax checkers.

### DIFF
--- a/syntax_checkers/c.vim
+++ b/syntax_checkers/c.vim
@@ -58,6 +58,9 @@
 " setting are removed from the result set:
 "
 "   let g:syntastic_c_remove_include_errors = 1
+"
+" Use variable 'g:syntastic_c_errorformat' to set custom error format string:
+"   let g:syntastic_c_errorformat = '%f:%l:%c: %trror: %m'
 
 if exists('loaded_c_syntax_checker')
     finish
@@ -85,6 +88,10 @@ function! SyntaxCheckers_c_GetLocList()
                \ 'identifier is reported only%.%#,%-G%f:%l: %#error: %#for '.
                \ 'each function it appears%.%#,%-GIn file included%.%#,'.
                \ '%-G %#from %f:%l\,,%f:%l:%c: %m,%f:%l: %trror: %m,%f:%l: %m'
+
+    if exists('g:syntastic_c_errorformat')
+        let errorformat = g:syntastic_c_errorformat
+    endif
 
     " add optional user-defined compiler options
     let makeprg .= g:syntastic_c_compiler_options

--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -58,6 +58,9 @@
 " g:syntastic_cpp_include_dirs' setting are removed from the result set:
 "
 "   let g:syntastic_cpp_remove_include_errors = 1
+"
+" Use variable 'g:syntastic_cpp_errorformat' to set custom error format string:
+"   let g:syntastic_cpp_errorformat = '%f:%l:%c: %trror: %m'
 
 if exists('loaded_cpp_syntax_checker')
     finish
@@ -78,6 +81,10 @@ endif
 function! SyntaxCheckers_cpp_GetLocList()
     let makeprg = 'g++ -fsyntax-only '
     let errorformat =  '%-G%f:%s:,%f:%l:%c: %m,%f:%l: %m'
+
+    if exists('g:syntastic_cpp_errorformat')
+        let errorformat = g:syntastic_cpp_errorformat
+    endif
 
     if exists('g:syntastic_cpp_compiler_options')
         let makeprg .= g:syntastic_cpp_compiler_options


### PR DESCRIPTION
Default errorformat string does not work sometimes causing warnings to be treated as errors. This option allows user to configure it from ~/.vimrc.
