### PR TITLE
Include results from CoffeeLint if available

### DIFF
--- a/syntax_checkers/coffee.vim
+++ b/syntax_checkers/coffee.vim
@@ -19,9 +19,23 @@ if !executable("coffee")
     finish
 endif
 
+
 function! SyntaxCheckers_coffee_GetLocList()
     let makeprg = 'coffee -c -l -o /tmp '.shellescape(expand('%'))
     let errorformat =  'Syntax%trror: In %f\, %m on line %l,%EError: In %f\, Parse error on line %l: %m,%EError: In %f\, %m on line %l,%W%f(%l): lint warning: %m,%-Z%p^,%W%f(%l): warning: %m,%-Z%p^,%E%f(%l): SyntaxError: %m,%-Z%p^,%-G%.%#'
 
-    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+    let coffee_results = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+
+    let lint_results = []
+    if executable("coffeelint")
+      let lint_options = ''
+      if(exists('g:coffee_lint_options'))
+        let lint_options = g:coffee_lint_options
+      endif
+      let coffeelint = 'coffeelint --csv '.lint_options.' '.shellescape(expand('%'))
+      echo coffeelint
+      let lint_results = SyntasticMake({ 'makeprg': coffeelint, 'errorformat': '%f\,%l\,error\,%m' })
+    endif
+
+    return coffee_results + lint_results
 endfunction


### PR DESCRIPTION
Respects the same options configuration as the vim-coffee-script plugin.
