### PR TITLE
Fix warning suppression in rspec files (fixes the fixed #290) 

### DIFF
--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_ruby_GetLocList()
     "  foo.should == 'bar'
     "
     "which always generate the warning below
-    let errorformat = '%-G%.%#warning: useless use of == in void context'
+    let errorformat = '%-G%.%#warning: possibly useless use of == in void context'
 
     let errorformat .=  ',%-GSyntax OK,%E%f:%l: syntax error\, %m,%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
Hi,

when running syntastic on rspec files i still (despite having syntastic at commit `6e2b7dd1900173611795bde8c8cc660618691d19`) get the warnings described in #290.

This fixes them on ruby 1.9.3-p125.

```
fschumac:..._git/project[master,◷]> ruby -w -T1 -c spec/lib/project/feature_spec.rb                  
spec/lib/project/feature_spec.rb:21: warning: possibly useless use of == in void context
spec/lib/project/feature_spec.rb:32: warning: possibly useless use of == in void context
Syntax OK
```
