### PR TITLE
force display errors on

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -41,7 +41,7 @@ function! SyntaxCheckers_php_GetLocList()
         let errors = s:GetPHPCSErrors()
     endif
 
-    let makeprg = "php -l ".shellescape(expand('%'))
+    let makeprg = "php -d display_errors=1 -l ".shellescape(expand('%'))
     let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l'
     let errors = errors + SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
if in the ini file, php has display errors off this is what you see:

```
$ php -l contains-errors.php
Errors parsing contains-errors.php
$
```

Therefore force php to display errors, so the reason can be seen:

```
$ php -d display_errors=1 -l contains-errors.php
Parse error: syntax error, unexpected ')', expecting ']' in contains-errors.php

Errors parsing contains-errors.php
$
```
