### PR TITLE
Added support for g:syntastic_c_compiler

### DIFF
--- a/syntax_checkers/c.vim
+++ b/syntax_checkers/c.vim
@@ -10,7 +10,9 @@
 "
 "============================================================================
 "
-" Set your compiler executable with (defaults to gcc):
+" Set your compiler executable with (defaults to gcc). This will only work for
+" compilers providing the -fsyntax-only flag. Currently, only gcc and clang
+" have been tested.
 "
 "   let g:syntastic_c_compiler = 'clang'
 "


### PR DESCRIPTION
Hello,

In the same vein as the g:syntastic_cpp_compiler pull request[1], I propose an equivalent option in C, g:syntastic_c_compiler, to change the compiler used in C syntax checking, to allow other compilers like clang.

[1] : https://github.com/scrooloose/syntastic/pull/296
