### PR TITLE
Fixes issue #311

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -243,7 +243,10 @@ function! s:ModeMapAllowsAutoChecking()
 endfunction
 
 function! s:BufHasErrorsOrWarningsToDisplay()
-    return len(s:Errors()) || (!g:syntastic_quiet_warnings && !empty(s:LocList()))
+    if empty(s:LocList())
+        return 0
+    endif
+    return len(s:Errors()) || !g:syntastic_quiet_warnings
 endfunction
 
 function! s:Errors()


### PR DESCRIPTION
s:Errors() function loops through the location list lookin for errors
and caches the result. The function is called indirectly by
SynasticStatuslineFlag before the location list has content. This patch
ensures s:Errors only gets called if location list has content.
