### PR TITLE
PHP: Work with php-5.3 and php-5.4

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -40,8 +40,8 @@ function! SyntaxCheckers_php_GetLocList()
 
     let errors = []
 
-    let makeprg = "php -l -d error_reporting=E_ALL -d display_errors=0 -d error_log='' ".shellescape(expand('%'))
-    let errorformat='%-GNo syntax errors detected in%.%#,PHP Parse error: %#syntax %trror\, %m in %f on line %l,PHP Fatal %trror: %m in %f on line %l,%-GErrors parsing %.%#,%-G\s%#,Parse error: %#syntax %trror\, %m in %f on line %l,Fatal %trror: %m in %f on line %l,PHP Parse %trror: %m in %f on line %l'
+    let makeprg = "php -l -d error_reporting=E_ALL -d display_errors=1 -d log_errors=0 ".shellescape(expand('%'))
+    let errorformat='%-GNo syntax errors detected in%.%#,Parse error: %#syntax %trror\ , %m in %f on line %l,Parse %trror: %m in %f on line %l,Fatal %trror: %m in %f on line %l,%-G\s%#,%-GErrors parsing %.%#'
     let errors = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 
     if empty(errors) && !g:syntastic_phpcs_disable && executable("phpcs")


### PR DESCRIPTION
The current makeprg doesn't work with php-5.3. display_errors=0 has
disabled error outputting and error_log='' disables the error log. With
php-5.4 error_log='' is causing errors to be logged to stderr.

This patch disables the error_log and enables display_errors.
Theoretically errors are displayed on stdout, however php in mountain
lion seems to insist on outputting to stderr.

As we're now displaying errors rather than logging them to error format
has changed to no longer include 'PHP ' and I've removed duplicates.

This has been tested with PHP 5.3.13 with Suhosin-Patch (cli) (built: Jun 20
2012 17:05:20)  (mountain lion) and PHP 5.4.4 (cli) (built: Jul  2 2012
16:33:50) Fedora 17
