### PR TITLE
Fix issue #303 FilterLocList

### DIFF
--- a/syntax_checkers/sh.vim
+++ b/syntax_checkers/sh.vim
@@ -44,7 +44,8 @@ function! SyntaxCheckers_sh_GetLocList()
             call add(result, {'lnum' : line,
                             \ 'text' : msg,
                             \ 'bufnr': bufnr(''),
-                            \ 'type': 'E' })
+                            \ 'type': 'E',
+                            \ 'valid': 1})
         endfor
         return result
     endif


### PR DESCRIPTION
999d3c1b added a filter on the errors list that checks for key/value
valid:1 in each element of the errors list. sh.vim doesn't use
SyntasticMake to check for errors so needs to add {valid:1} to each
result.
