### PR TITLE
Change executable() to system call in the ruby exec check

### DIFF
--- a/syntax_checkers/ruby.vim
+++ b/syntax_checkers/ruby.vim
@@ -23,7 +23,8 @@ if !exists("g:syntastic_ruby_exec")
 endif
 
 "bail if the user doesnt have ruby installed where they said it is
-if !executable(expand(g:syntastic_ruby_exec))
+silent! system(shellescape(expand(g:syntastic_ruby_exec) . ' -v'))
+if v:shell_error != 0
     finish
 endif
 


### PR DESCRIPTION
Vim's executable() doesn't allow to use more sophisticated
ruby executables like, for example: "rvm 1.9.3 ruby do ruby".

Sometimes, it is desired to perform syntax validation under
a vanilla MRI while the default Ruby interpreter remains unchanged.

RVM allows it, and that approach is especially helpful in case of
JRuby, because JRuby error messages are less informative, and
JRuby starts much more slower than MRI. That results in a significant
delay on every file save.
