### PR TITLE
Always update the location list, even if empty

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -132,9 +132,7 @@ function! s:UpdateErrors(auto_invoked)
         call s:CacheErrors()
     end
 
-    if s:BufHasErrorsOrWarningsToDisplay()
-        call setloclist(0, s:LocList())
-    endif
+    call setloclist(0, s:LocList())
 
     if g:syntastic_enable_balloons
         call s:RefreshBalloons()


### PR DESCRIPTION
It's kind of weird leaving the last set of errors in the location list if the latest lint is clean.

While syntastic cleans up all the signs when the lint is clean, other things use the location list as an indicator of errors.

This should fix the problems people are seeing in #267. See that issue for a much longer explanation of the problem I was having and how I debugged it.
