### PR TITLE
Add g:syntastic_check_on_save option

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -102,6 +102,9 @@ if !exists("g:syntastic_loc_list_height")
     let g:syntastic_loc_list_height = 10
 endif
 
+if !exists("g:syntastic_check_on_save")
+    let g:syntastic_check_on_save = 1
+endif
 command! SyntasticToggleMode call s:ToggleMode()
 command! SyntasticCheck call s:UpdateErrors(0) <bar> redraw!
 command! Errors call s:ShowLocList()
@@ -115,7 +118,7 @@ augroup syntastic
     endif
 
     autocmd BufReadPost * if g:syntastic_check_on_open | call s:UpdateErrors(1) | endif
-    autocmd BufWritePost * call s:UpdateErrors(1)
+    autocmd BufWritePost * if g:syntastic_check_on_save | call s:UpdateErrors(1) | endif
 
     autocmd BufWinEnter * if empty(&bt) | call s:AutoToggleLocList() | endif
     autocmd BufWinLeave * if empty(&bt) | lclose | endif


### PR DESCRIPTION
I add a option called "g:syntastic_check_on_save" to control the check behavior when saving
If g:syntastic_check_on_save set to 1,the code will be checked while saving.
the g:syntastic_check_on_save default 1.
