### PR TITLE
Added support for multi-line error messages in go.vim

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -11,7 +11,7 @@
 "============================================================================
 function! SyntaxCheckers_go_GetLocList()
     let makeprg = 'go build -o /dev/null'
-    let errorformat = '%f:%l:%c:%m,%f:%l%m,%-G#%.%#'
+    let errorformat = '%f:%l:%c:%m,%E%f:%l:%m,%C%m,%-G#%.%#'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
I realized some messages were being truncated and then I discovered that there's also multi-line errors output by the compiler. This also removes a spurious : at the beginning of some single-line error messages.
