### PR TITLE
ruby/mri: ignore efm lines that start ...

### DIFF
--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -24,6 +24,12 @@ function! SyntaxCheckers_ruby_GetLocList()
     "the word "possibly" in the warning
     let errorformat = '%-G%.%#warning: %\(possibly %\)%\?useless use of == in void context'
 
-    let errorformat .=  ',%-GSyntax OK,%E%f:%l: syntax error\, %m,%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#'
+    " filter out lines starting with ...
+    " long lines are truncated and wrapped in ... %p then returns the wrong
+    " column offset
+    let errorformat .= ',%-G%\%.%\%.%\%.%.%#'
+
+    let errorformat .= ',%-GSyntax OK,%E%f:%l: syntax error\, %m'
+    let errorformat .= ',%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
If the line a ruby error occurs on is 'too long' it will truncate the line it
displays in the error output and wrap it in `...`. This breaks %p from finding
the correct column so this patch ignores lines starting with `...`

e.g. %p working

```
ruby -w -T1 -c broken.rb
broken.rb:2: syntax error, unexpected tIDENTIFIER, expecting $end
puts sprintf "%d, %.2f, %.2f, %.2f, %d" k, v
                                         ^
```

%p not working

```
ruby -w -T1 -c broken.rb
broken.rb:2: syntax error, unexpected tIDENTIFIER, expecting $end
...tf "%d, %.2f, %.2f, %.2f, %d" k, v[:cost], v[:val], v[:carri...
...                               ^
```
