### PR TITLE
By default do not check sass partials.

### DIFF
--- a/syntax_checkers/sass.vim
+++ b/syntax_checkers/sass.vim
@@ -19,6 +19,11 @@ if !executable("sass")
     finish
 endif
 
+"By default do not check partials as unknown variables are a syntax error
+if !exists("g:syntastic_sass_check_partials")
+    let g:syntastic_sass_check_partials = 0
+endif
+
 "use compass imports if available
 let s:imports = ""
 if executable("compass")
@@ -26,6 +31,9 @@ if executable("compass")
 endif
 
 function! SyntaxCheckers_sass_GetLocList()
+    if !g:syntastic_sass_check_partials && expand('%:t')[0] == '_'
+        return []
+    end
     let makeprg='sass --no-cache '.s:imports.' --check '.shellescape(expand('%'))
     let errorformat = '%ESyntax %trror:%m,%C        on line %l of %f,%Z%.%#'
     let errorformat .= ',%Wwarning on line %l:,%Z%m,Syntax %trror on line %l: %m'


### PR DESCRIPTION
Sass partials depend on their parents files for context. This patch disables the
syntax checking for partials by default because of this. To enable checking of
partials let g:syntastic_sass_check_partials = 1. Fixes issue #300.
## 

The only problem I have with this is - 

When _partial.scss has an error in it, and is  imported by boss.scss. When SyntasticCheck is run on boss.scss, it reports an error in _partial.scss. I have autojump enabled so it jumps to the error in the _partial.scss buffer, which doesn't have the loclist because it's a buffer variable. So, especially with check_on_open I'm looking at a buffer with the wrong file, and no errors. I did notice that when the C checker jumps to an h file, :lopen still displays the errors, but I haven't had time to work out how it's doing that yet.
