### PR TITLE
ruby: Use RVM to automatically detect which checker to use

### DIFF
--- a/syntax_checkers/ruby.vim
+++ b/syntax_checkers/ruby.vim
@@ -8,27 +8,62 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
-"Supports MRI and JRuby but loads the MRI syntax checker by default.
-"
+"Supports MRI, JRuby and MacRuby but loads the MRI syntax checker by default.
+"Use the g:syntastic_ruby_exec option to specify the executable to call
 "Use the g:syntastic_ruby_checker option to specify which checker to load -
-"set it to "jruby" to load the jruby checker.
+"it will default to 'macruby' or 'jruby' if that is the value of
+"g:syntastic_ruby_exec
+"If you have rvm installed the correct exec and checker will be set based on
+"your currently selected ruby
+"
+"Examples:
+"set _exec | set _checker | rvm | output_exec  | output_checker
+"no        | no           | no  | ruby         | mri
+"no        | no           | yes | from rvm     | from rvm
+"ruby      | no           |     | ruby         | mri
+"ruby18    | no           |     | ruby18       | mri
+"no        | jruby        |     | jruby        | jruby
+"jruby     | no           |     | jruby        | jruby
+"jruby     | jruby        |     | jruby        | jruby
+"ruby18    | jruby        |     | ruby18       | jruby
 "============================================================================
 if exists("loaded_ruby_syntax_checker")
     finish
 endif
 let loaded_ruby_syntax_checker = 1
 
-if !exists("g:syntastic_ruby_exec")
-  let g:syntastic_ruby_exec = "ruby"
-endif
+function! s:is_jruby_or_macvim(str)
+    return "jruby" == a:str || "macvim" == a:str
+endfunction
 
-"bail if the user doesnt have ruby installed where they said it is
-if !executable(expand(g:syntastic_ruby_exec))
-    finish
+if !exists("g:syntastic_ruby_exec")
+    let g:syntastic_ruby_exec = "ruby"
+    let s:i_set_ruby_exec = 1
+    if !exists(g:syntastic_ruby_checker) && executable("rvm")
+        let ident = system("rvm tools identifier")
+        let ident = substitute(ident, '-.*', '', '')
+        if s:is_jruby_or_macvim(ident)
+            let g:syntastic_ruby_checker = ident
+            let s:i_set_ruby_checker = 1
+        endif
+    endif
 endif
 
 if !exists("g:syntastic_ruby_checker")
-    let g:syntastic_ruby_checker = "mri"
+    if s:is_jruby_or_macvim(g:syntastic_ruby_exec)
+        let g:syntastic_ruby_checker = g:syntastic_ruby_exec
+    else
+        let g:syntastic_ruby_checker = "mri"
+    endif
+elseif !exists("s:i_set_ruby_checker") && exists("s:i_set_ruby_exec")
+    if s:is_jruby_or_macvim(g:syntastic_ruby_checker)
+        let g:syntastic_ruby_exec = g:syntastic_ruby_checker
+    endif
+endif
+
+"bail if the user doesnt have ruby installed where they said it is
+if !executable(g:syntastic_ruby_exec)
+    finish
 endif
 exec "runtime! syntax_checkers/ruby/" . g:syntastic_ruby_checker . ".vim"
 

--- a/syntax_checkers/ruby/jruby.vim
+++ b/syntax_checkers/ruby/jruby.vim
@@ -10,10 +10,9 @@
 "
 "============================================================================
 function! SyntaxCheckers_ruby_GetLocList()
-    if has('win32')
-        let makeprg = 'jruby -W1 -T1 -c '.shellescape(expand('%'))
-    else
-        let makeprg = 'RUBYOPT= jruby -W1 -c '.shellescape(expand('%'))
+    let makeprg = g:syntastic_ruby_exec . ' -W1 -T1 -c '.shellescape(expand('%'))
+    if !has('win32')
+        let makeprg = 'RUBYOPT= ' . makeprg
     endif
     let errorformat =  '%-GSyntax OK for %f,%ESyntaxError in %f:%l: syntax error\, %m,%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#'
 

--- a/syntax_checkers/ruby/macruby.vim
+++ b/syntax_checkers/ruby/macruby.vim
@@ -9,7 +9,7 @@
 "
 "============================================================================
 function! SyntaxCheckers_ruby_GetLocList()
-    let makeprg = 'RUBYOPT= macruby -W1 -c '.shellescape(expand('%'))
+    let makeprg = 'RUBYOPT= ' . g:syntastic_ruby_exec . ' -W1 -c '.shellescape(expand('%'))
     let errorformat =  '%-GSyntax OK,%E%f:%l: syntax error\, %m,%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
- If _exec is unset, use rvm if available to determine which checker to use
- Use _exec for all checkers
- Set _exec to preserve old behaviour of only setting checker for jruby/macruby
## 

OK, I admit this code is confusing, but I didn't want to break any of the old behaviours. There's a table in ruby.vim that hopefully shows what happens depending on which variables are set. This should also 'Fix' the last bit of #185.
