### PR TITLE
Make syntastic_cpp_compiler_options empty if unset

### DIFF
--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -100,6 +100,8 @@ function! SyntaxCheckers_cpp_GetLocList()
 
     if exists('g:syntastic_cpp_compiler_options')
         let makeprg .= g:syntastic_cpp_compiler_options
+    else
+        let g:syntastic_cpp_compiler_options = ''
     endif
 
     let makeprg .= ' ' . shellescape(expand('%')) .


### PR DESCRIPTION
This avoids users explicly having to set the cpp options as an empty string,
since the variable is later used to set makeprg.
