### PR TITLE
Fix puppet parser validation for puppet 3.0.0 (and versions 2.61-2.7.9)

### DIFF
--- a/syntax_checkers/puppet.vim
+++ b/syntax_checkers/puppet.vim
@@ -72,14 +72,8 @@ function! s:getPuppetMakeprg()
         let makeprg = 'puppet parser validate ' .
                     \ shellescape(expand('%')) .
                     \ ' --color=false'
-
-        "add --ignoreimport for versions < 2.7.10
-        if s:PuppetVersion()[2] < '10'
-            let makeprg .= ' --ignoreimport'
-        endif
-
     else
-        let makeprg = 'puppet --color=false --parseonly --ignoreimport '.shellescape(expand('%'))
+        let makeprg = 'puppet --color=false --parseonly '.shellescape(expand('%'))
     endif
     return makeprg
 endfunction
@@ -94,6 +88,13 @@ function! SyntaxCheckers_puppet_GetLocList()
         "are any syntax errors
         let errorformat = '%-Gerr: Try ''puppet help parser validate'' for usage,'
         let errorformat .= 'err: Could not parse for environment %*[a-z]: %m at %f:%l'
+
+        "Puppet 3.0.0 changes this from "err:" to "Error:"
+        "reset errorformat in that case
+        if SyntasticIsVersionAtLeast(s:PuppetVersion(), [3,0,0])
+            let errorformat = '%-GError: Try ''puppet help parser validate'' for usage,'
+            let errorformat .= 'Error: Could not parse for environment %*[a-z]: %m at %f:%l'
+        endif
 
         let errors = errors + SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
     endif


### PR DESCRIPTION
The error message in 'puppet parser validate' changed between Puppet 2.x
and Puppet 3.0.0, preventing syntax errors from being caught.

In addition, the logic to apply the "--ignoreimport" flag was falsely triggering 
on 3.0.0, because it was written assuming a major version of "2".  The
--ignoreimport flag has been broken since 2.6.1, so I removed all of that
logic.  In theory, it could be re-added for 2.6.0 and 0.2x.x, but the
version number checking already didn't handle 0.2x.x, so I didn't reach back 
that far.
