### PR TITLE
Don't create precompiled headers when checking them

### DIFF
--- a/syntax_checkers/cpp.vim
+++ b/syntax_checkers/cpp.vim
@@ -11,7 +11,6 @@
 "============================================================================
 
 " in order to also check header files add this to your .vimrc:
-" (this usually creates a .gch file in your source directory)
 "
 "   let g:syntastic_cpp_check_header = 1
 "
@@ -108,8 +107,16 @@ function! SyntaxCheckers_cpp_GetLocList()
 
     if expand('%') =~? '\%(.h\|.hpp\|.hh\)$'
         if exists('g:syntastic_cpp_check_header')
+            if has('win32')
+                let null_device = '-o nul'
+            elseif has('unix') || has('mac')
+                let null_device = '-o /dev/null'
+            else
+                let null_device = ''
+            endif
             let makeprg = g:syntastic_cpp_compiler.' -c '.shellescape(expand('%')) .
                         \ ' ' . g:syntastic_cpp_compiler_options .
+                        \ ' ' . null_device .
                         \ ' ' . syntastic#c#GetIncludeDirs('cpp')
         else
             return []


### PR DESCRIPTION
Hi.

I've created this small change to avoid creating the *.h.gch precompiled headers when checking such headers.

It could be done passing the "-o /dev/null" with the options, but IMHO, it makes more sense this way, since I doubt many people will know that such thing is possible, or how to do it (maybe not many people run gcc by hand), and I also doubt that there are many people that want precompiled headers generated by syntastic (probably even less in the same directory as the source).

I also considered doing this through the default options, that is, setting the default compiler options to "-o /dev/null" if the user doesn't set it to something (instead of an empty string), but then, for those that set something, will lose this behaviour.

Of course is up to you to decide, but IMHO, checking headers should be no different than checking sources, and the precompiled headers are annoyingly big to lay in the source tree (I have a different build directory), so the default should be not generating them.

Regards, and thanks a lot for syntastic. :-)
