### PR TITLE
fix erlang syntax checker

### DIFF
--- a/syntax_checkers/erlang.vim
+++ b/syntax_checkers/erlang.vim
@@ -15,16 +15,15 @@ endif
 let loaded_erlang_syntax_checker = 1
 
 "bail if the user doesnt have escript installed
-if !executable("erl")
+if !executable("escript")
     finish
 endif
 
-"g:syntastic_erlc_attrs currently need to set in .vimrc
-"TODO: make g:syntastic_erlc_attrs project specific
-if !exists("g:syntastic_erlc_attrs")
-    let g:syntastic_erlc_attrs=""
+let s:check_file = expand('<sfile>:p:h') . '/erlang_check_file.erl'
+if !exists("g:syntastic_erlc_include_path")
+    let g:syntastic_erlc_include_path=""
 endif
-let s:check_file = expand('<sfile>:p:h') . '/erlang_check_file "'.g:syntastic_erlc_attrs.'"'
+
 
 function! SyntaxCheckers_erlang_GetLocList()
     let extension = expand('%:e')
@@ -36,10 +35,10 @@ function! SyntaxCheckers_erlang_GetLocList()
         if match(shebang, 'escript') >= 0
             let makeprg = 'escript -s '.shellescape(expand('%:p'))
         else
-            let makeprg = s:check_file . ' '. shellescape(expand('%:p'))
+            let makeprg = s:check_file . ' '. shellescape(expand('%:p')).' '.g:syntastic_erlc_include_path
         endif
     else
-        let makeprg =  s:check_file . ' ' . shellescape(expand('%:p'))
+        let makeprg =  s:check_file . ' ' . shellescape(expand('%:p')).' '.g:syntastic_erlc_include_path
     endif
     let errorformat = '%f:%l:\ %tarning:\ %m,%E%f:%l:\ %m'
 

--- a/syntax_checkers/erlang_check_file
+++ b/syntax_checkers/erlang_check_file
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-INCLUDE_DIR=" -pa `dirname ${2}`/../include "
-erl ${1} ${INCLUDE_DIR} -compile ${2}

--- a/syntax_checkers/erlang_check_file.erl
+++ b/syntax_checkers/erlang_check_file.erl
@@ -1,0 +1,16 @@
+#!/usr/bin/env escript
+-export([main/1]).
+
+main([FileName| LibDirs=[_|_]]) ->
+    code:add_pathsa(LibDirs),
+    main([FileName]);
+
+main([FileName]) ->
+    compile:file(FileName, [warn_obsolete_guard,
+                            warn_unused_import,
+                            warn_shadow_vars,
+                            warn_export_vars,
+                            strong_validation,
+                            report,
+                            {i, filename:dirname(FileName) ++ "/../include"}
+                        ]).


### PR DESCRIPTION
Hi 
This pull request related to #380
There is more elegant way which fixes issue with `*.beam` files in vim work directory and needs less changes in original @kTT's code.
Replace g:syntastic_erlc_attrs with g:sintastic_erlc_include_path that can contain something like this:

``` vim
g:syntastic_erlc_include_path="~/workspace/erlanglib/*/ebin ~/workspace/myproj/lib/*/ebin"
```
