### PR TITLE
Add typical deps locations for includes

### DIFF
--- a/syntax_checkers/erlang_check_file.erl
+++ b/syntax_checkers/erlang_check_file.erl
@@ -13,5 +13,6 @@ main([FileName]) ->
                             strong_validation,
                             report,
                             {i, filename:dirname(FileName) ++ "/../include"},
+                            {i, filename:dirname(FileName) ++ "/../deps"},
                             {i, filename:dirname(FileName) ++ "/../../../deps"}
                         ]).


### PR DESCRIPTION
rebar apps are typically configured to deposit deps in an app deps folder.  There are two relative locations commonly used - this change adds those locations to the include path, allowing for app dependencies to be included for compile-on-save.   This makes syntastic compilation much more useful in larger erlang apps that use rebar.
