### PR TITLE
Support less/rst/typescript syntax checkers on Windows platforms

### DIFF
--- a/syntax_checkers/less.vim
+++ b/syntax_checkers/less.vim
@@ -42,8 +42,12 @@ else
 end
 
 function! SyntaxCheckers_less_GetLocList()
+    let devnull = '/dev/null'
+    if has('win32')
+        let devnull = 'NUL'
+    endif
     let makeprg = s:check_file . ' ' . g:syntastic_less_options . ' ' .
-                \ shellescape(expand('%')) . ' /dev/null'
+                \ shellescape(expand('%')) . ' ' . devnull
     let errorformat = '%m in %f:%l:%c'
 
     return SyntasticMake({ 'makeprg': makeprg,

--- a/syntax_checkers/rst.vim
+++ b/syntax_checkers/rst.vim
@@ -24,8 +24,12 @@ if !executable("rst2pseudoxml.py")
 endif
 
 function! SyntaxCheckers_rst_GetLocList()
+    let devnull = '/dev/null'
+    if has('win32')
+        let devnull = 'NUL'
+    endif
     let makeprg = 'rst2pseudoxml.py --report=2 --exit-status=1 ' .
-      \ shellescape(expand('%')) . ' /dev/null'
+      \ shellescape(expand('%')) . ' ' . devnull
 
     let errorformat = '%f:%l:\ (%tNFO/1)\ %m,
       \%f:%l:\ (%tARNING/2)\ %m,

--- a/syntax_checkers/typescript.vim
+++ b/syntax_checkers/typescript.vim
@@ -14,7 +14,11 @@ if !executable("tsc")
 endif
 
 function! SyntaxCheckers_typescript_GetLocList()
-    let makeprg = 'tsc ' . shellescape(expand("%")) . ' --out /dev/null'
+    let devnull = '/dev/null'
+    if has('win32')
+        let devnull = 'NUL'
+    endif
+    let makeprg = 'tsc ' . shellescape(expand("%")) . ' --out ' . devnull
     let errorformat = '%f (%l\,%c): %m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
by directing output to NUL instead of /dev/null
