### PR TITLE
Prevent tabs in error messages from causing "press enter" prompt

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -439,6 +439,8 @@ function! s:WideMsg(msg)
     let old_ruler = &ruler
     let old_showcmd = &showcmd
 
+    "convert tabs to spaces so that the tabs count towards the window width
+    "as the proper amount of characters
     let msg = substitute(a:msg, "\t", repeat(" ", &tabstop), "g")
     let msg = strpart(msg, 0, winwidth(0)-1)
 


### PR DESCRIPTION
I was finding that the error status message would sometimes wrap when I move the cursor on its line, and would show a "Press ENTER or type command to continue" prompt, which was annoying. This happened when editing Java source files, because the syntax checker for Java prints the line as well as the error message. The Java syntax checker should probably not print the line in the first place, since we can already see the line in the editor, but at least this fix solves the problem of line wrapping which could come up with other syntax checkers as well.
