### PR TITLE
The warnings were shown as errors when using flake8

### DIFF
--- a/syntax_checkers/python/flake8.vim
+++ b/syntax_checkers/python/flake8.vim
@@ -23,6 +23,6 @@ endfunction
 
 function! SyntaxCheckers_python_GetLocList()
     let makeprg = 'flake8 '.g:syntastic_python_checker_args.' '.shellescape(expand('%'))
-    let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %m,%E%f:%l: %m,%-G%.%#'
+    let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %m,%W%f:%l: %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
This pull request makes reference to the Issue #391

When using flake8 to check Python code, the warnings were shown as errors by syntastic.

This change is working fine for me.
