### PR TITLE
Fix ruby RbConfig deprecation warning

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -205,7 +205,7 @@ function! syntastic#c#CheckRuby()
     if executable('ruby')
         if !exists('s:ruby_flags')
             let s:ruby_flags = system('ruby -r rbconfig -e '
-                        \ . '''puts Config::CONFIG["archdir"]''')
+                        \ . '''puts RbConfig::CONFIG["archdir"]''')
             let s:ruby_flags = substitute(s:ruby_flags, "\n", '', '')
             let s:ruby_flags = ' -I' . s:ruby_flags
         endif


### PR DESCRIPTION
Vim displays a warning when saving c files:
E492: Not an editor command:  -I-e:1: Use RbConfig instead of obsolete and deprecated Config./Users/andrew/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/x86_64-darw
in12.0.0^@ -I-e:1: Use RbConfig instead of obsolete and deprecated Config./Users/andrew/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/x86_64-darwin12.0.0^@ -I-e:1:
Use RbConfig instead of obsolete and deprecated Config./Users/andrew/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/x86_64-darwin12.0.0^@ -I-e:1: Use RbConfig instea
d of obsolete and deprecated Config./Users/andrew/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/x86_64-darwin12.0.0^@
