### PR TITLE
Ensure existence of SASS cache location

### DIFF
--- a/syntax_checkers/sass.vim
+++ b/syntax_checkers/sass.vim
@@ -21,7 +21,15 @@ endif
 
 "sass caching for large files drastically speeds up the checking, but store it
 "in a temp location otherwise sass puts .sass_cache dirs in the users project
-let s:sass_cache_location = tempname()
+let s:sass_cache_location = ''
+
+" ensure that the cache location is always writable
+function s:getCacheLocation()
+    if !isdirectory(s:sass_cache_location)
+        let s:sass_cache_location = tempname()
+    endif
+    return s:sass_cache_location
+endfunction
 
 "By default do not check partials as unknown variables are a syntax error
 if !exists("g:syntastic_sass_check_partials")
@@ -38,7 +46,7 @@ function! SyntaxCheckers_sass_GetLocList()
     if !g:syntastic_sass_check_partials && expand('%:t')[0] == '_'
         return []
     end
-    let makeprg='sass --cache-location '.s:sass_cache_location.'  '.s:imports.' --check '.shellescape(expand('%'))
+    let makeprg='sass --cache-location '.s:getCacheLocation().'  '.s:imports.' --check '.shellescape(expand('%'))
     let errorformat = '%ESyntax %trror:%m,%C        on line %l of %f,%Z%.%#'
     let errorformat .= ',%Wwarning on line %l:,%Z%m,Syntax %trror on line %l: %m'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
On long running VIM processes, it's possible for the temp location to be
destroyed. In theory this shouldn't happen, but some environments can be
unpredictable.

Also doesn't generate the temp location until the last possible moment.
