### PR TITLE
Add -fno-code to the call to ghc-mod, which speeds up haskell syntax checking

### DIFF
--- a/syntax_checkers/haskell/ghc-mod.vim
+++ b/syntax_checkers/haskell/ghc-mod.vim
@@ -11,7 +11,7 @@
 "============================================================================
 
 if !exists('g:syntastic_haskell_checker_args')
-    let g:syntastic_haskell_checker_args = '--ghcOpts="-fno-code" --hlintOpt="--language=XmlSyntax"'
+    let g:syntastic_haskell_checker_args = '--ghcOpt="-fno-code" --hlintOpt="--language=XmlSyntax"'
 endif
 
 function! SyntaxCheckers_haskell_GetLocList()


### PR DESCRIPTION
Since we're only using ghc to check and lint the file and not actually create output, we can pass -fno-code which omits code generation and speeds up the check quite a bit.
