### PR TITLE
docbook checker: added quotes to args in expand() call

### DIFF
--- a/syntax_checkers/docbk.vim
+++ b/syntax_checkers/docbk.vim
@@ -21,7 +21,7 @@ endif
 
 function! SyntaxCheckers_docbk_GetLocList()
 
-    let makeprg="xmllint --xinclude --noout --postvalid ".shellescape(expand(%:p))
+    let makeprg="xmllint --xinclude --noout --postvalid ".shellescape(expand("%:p"))
     let errorformat='%E%f:%l: parser error : %m,%W%f:%l: parser warning : %m,%E%f:%l:%.%# validity error : %m,%W%f:%l:%.%# validity warning : %m,%-Z%p^,%-C%.%#,%-G%.%#'
     let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 


### PR DESCRIPTION
Very simple bug fix. The checker didn't work at all  for me without the quotes.
