### PR TITLE
Fix Cucumber::Undefined

### DIFF
--- a/syntax_checkers/cucumber.vim
+++ b/syntax_checkers/cucumber.vim
@@ -19,8 +19,16 @@ if !executable("cucumber")
     finish
 endif
 
+function! BundleExec()
+  if executable("bundle")
+    return 'bundle exec '
+  else
+    return ''
+  endif
+endfunction
+
 function! SyntaxCheckers_cucumber_GetLocList()
-    let makeprg = 'cucumber --dry-run --quiet --strict --format pretty '.shellescape(expand('%'))
+    let makeprg = BundleExec() + 'cucumber --dry-run --quiet --strict --format pretty '.shellescape(expand('%'))
     let errorformat =  '%f:%l:%c:%m,%W      %.%# (%m),%-Z%f:%l:%.%#,%-G%.%#'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
Hi, I and my team friends were having problems with cucumber syntax checker.
'Cause it always showed warns about errors and the command line showed "Cucumber::Undefined".

I believe that I fixed it.

Congratz for this excelent plugin!

Tanks,
Bruno Vicenzo.
