### PR TITLE
Fix TypeScript errorformat for latest version of the compiler

### DIFF
--- a/syntax_checkers/typescript.vim
+++ b/syntax_checkers/typescript.vim
@@ -15,6 +15,6 @@ endif
 
 function! SyntaxCheckers_typescript_GetLocList()
     let makeprg = 'tsc ' . shellescape(expand("%")) . ' --out ' . syntastic#util#DevNull()
-    let errorformat = '%f(%l\,%c): %m'
+    let errorformat = '%f\ %#(%l\,%c): %m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
Looks like they removed a space.
