### PR TITLE
Add python checker that uses python itself

### DIFF
--- a/syntax_checkers/python.vim
+++ b/syntax_checkers/python.vim
@@ -23,5 +23,5 @@ if !exists('g:syntastic_python_checker_args')
     let g:syntastic_python_checker_args = ''
 endif
 
-let s:supported_checkers = ["flake8", "pyflakes", "pylint"]
+let s:supported_checkers = ["flake8", "pyflakes", "pylint", "python"]
 call SyntasticLoadChecker(s:supported_checkers, 'python')

--- a/syntax_checkers/python/python.vim
+++ b/syntax_checkers/python/python.vim
@@ -1,0 +1,27 @@
+"============================================================================
+"File:        python.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Author:      Artem Nezvigin <artem at artnez dot com>
+"
+" `errorformat` derived from:
+" http://www.vim.org/scripts/download_script.php?src_id=1392
+"
+"============================================================================
+
+function! SyntaxCheckers_python_GetLocList()
+    let l:path = shellescape(expand('%'))
+    let l:cmd = "compile(open(" . l:path . ").read(), " . l:path . ", 'exec')"
+    let l:makeprg = 'python -c "' . l:cmd . '"'
+
+    let l:errorformat =
+        \ "\%A\ \ File\ \"%f\"\\\,\ line\ %l\\\,%m," .
+        \ "\%C\ \ \ \ %.%#," .
+        \ "\%+Z%.%#Error\:\ %.%#," .
+        \ "\%A\ \ File\ \"%f\"\\\,\ line\ %l," .
+        \ "\%+C\ \ %.%#," .
+        \ "\%-C%p^," .
+        \ "\%Z%m," .
+        \ "\%-G%.%#"
+
+    return SyntasticMake({ 'makeprg': l:makeprg, 'errorformat': l:errorformat })
+endfunction


### PR DESCRIPTION
The advantage to this is that no 3rd party modules are required. People
new to Python probably won't have flake8/pyflakes/pylint installed. This
will get them basic syntax checking (no linting) out of the box.
