### PR TITLE
allow flake8 to work correctly with windows paths

### DIFF
--- a/syntax_checkers/python/flake8.vim
+++ b/syntax_checkers/python/flake8.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_python_GetHighlightRegex(i)
 endfunction
 
 function! SyntaxCheckers_python_GetLocList()
-    let makeprg = 'flake8 '.g:syntastic_python_checker_args.' '.shellescape(expand('%'))
+    let makeprg = 'python -m flake8.run '.g:syntastic_python_checker_args.' '.shellescape(expand('%'))
     let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %m,%W%f:%l: %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
When using syntastic with flake8 on a system with a messed up $PATH, i.e. some paths are missing (I guess), then flake8 would complain about not being able to import __main__.

This simple fix seems to fix that, as it skips the part where the _flake8_ binary is executed or something. Besides that, as far as I have tested it doesn't seem to break backwards compatibility. So, if anything, there's no loss ;)
