### PR TITLE
Configurable commands for checkers

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -697,10 +697,40 @@ function! SyntasticLoadChecker(ft)
         endif
     else
         for checker in checkers
-            if executable(checker)
+            if SyntasticCheckerCommand(a:ft, checker, "DEFAULT") != "DEFAULT"
+                    \ || executable(checker)
                 return s:LoadChecker(checker, a:ft)
             endif
         endfor
+    endif
+endfunction
+
+" Returns command name for given checker which will be used to call this
+" checker. User can override this command name by defining special variable
+" in own vimrc file. It makes Syntastic more flexible and usable
+" in complex environments.
+" You can pass default value for command in third argument.
+"
+" Usage:
+" SyntasticCheckerCommand('python', 'pyflakes')
+" SyntasticCheckerCommand('javascript', 'closure_java', 'java')
+"
+" Example of settings in .vimrc:
+" let g:syntastic_javascript_jshint_cmd = 'path/to/jshint/executable'
+" let g:syntastic_python_flake8_cmd = 'python26 -m flake8.run'
+" let g:syntastic_javascript_closure_java_cmd = '/home/user/jre1.7/bin/java'
+"
+function! SyntasticCheckerCommand(file_type, tool, ...)
+    let opt_name = 'g:syntastic_' . a:file_type . '_' . a:tool . '_cmd'
+    if exists(opt_name)
+        return {opt_name}
+    else
+        if a:0 > 0
+            let default = a:1
+        else
+            let default = a:tool
+        endif
+        return default
     endif
 endfunction
 

--- a/syntax_checkers/javascript/closurecompiler.vim
+++ b/syntax_checkers/javascript/closurecompiler.vim
@@ -36,8 +36,12 @@ function! SyntaxCheckers_javascript_GetLocList()
     else
         let file_list = shellescape(expand('%'))
     endif
+    let java_cmd = SyntasticCheckerCommand('javascript', 'closure_java', 'java')
 
-    let makeprg = 'java -jar ' . g:syntastic_javascript_closure_compiler_path . ' ' . g:syntastic_javascript_closure_compiler_options . ' --js ' . file_list
+    let makeprg = java_cmd . ' -jar ' 
+		    \ . g:syntastic_javascript_closure_compiler_path
+		    \ . ' ' . g:syntastic_javascript_closure_compiler_options
+		    \ . ' --js ' . file_list
     let errorformat = '%-GOK,%E%f:%l: ERROR - %m,%Z%p^,%W%f:%l: WARNING - %m,%Z%p^'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction

--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -15,7 +15,8 @@ endif
 function! SyntaxCheckers_javascript_GetLocList()
     " node-jshint uses .jshintrc as config unless --config arg is present
     let args = !empty(g:syntastic_javascript_jshint_conf) ? ' --config ' . g:syntastic_javascript_jshint_conf : ''
-    let makeprg = 'jshint ' . shellescape(expand("%")) . args
+    let makeprg = SyntasticCheckerCommand('javascript', 'jshint')
+			    \ .' ' . shellescape(expand("%")) . args
     let errorformat = '%ELine %l:%c,%Z\\s%#Reason: %m,%C%.%#,%f: line %l\, col %c\, %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'defaults': {'bufnr': bufnr('')} })
 endfunction

--- a/syntax_checkers/python/flake8.vim
+++ b/syntax_checkers/python/flake8.vim
@@ -22,7 +22,8 @@ function! SyntaxCheckers_python_GetHighlightRegex(i)
 endfunction
 
 function! SyntaxCheckers_python_GetLocList()
-    let makeprg = 'flake8 '.g:syntastic_python_checker_args.' '.shellescape(expand('%'))
+    let makeprg = SyntasticCheckerCommand('python', 'flake8') . ' '
+	    \ .g:syntastic_python_checker_args.' '.shellescape(expand('%'))
     let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %m,%W%f:%l: %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction

--- a/syntax_checkers/python/pyflakes.vim
+++ b/syntax_checkers/python/pyflakes.vim
@@ -23,7 +23,8 @@ function! SyntaxCheckers_python_GetHighlightRegex(i)
 endfunction
 
 function! SyntaxCheckers_python_GetLocList()
-    let makeprg = 'pyflakes '.g:syntastic_python_checker_args.' '.shellescape(expand('%'))
+    let makeprg = SyntasticCheckerCommand('python', 'pyflakes')
+		\ .' '.g:syntastic_python_checker_args .' '.shellescape(expand('%'))
     let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %m,%E%f:%l: %m,%-G%.%#'
 
     let errors = SyntasticMake({ 'makeprg': makeprg,

--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -5,10 +5,11 @@
 "
 "============================================================================
 function! SyntaxCheckers_python_GetLocList()
-    let makeprg = 'pylint '.g:syntastic_python_checker_args.' -f parseable -r n -i y ' .
-                \ shellescape(expand('%')) .
-                \ ' 2>&1 \| sed ''s_: \[\([RCW]\)_: \[W] \[\1_''' .
-                \ ' \| sed ''s_: \[\([FE]\)_:\ \[E] \[\1_'''
+    let makeprg = SyntasticCheckerCommand('python', 'pylint')
+	\ .' '.g:syntastic_python_checker_args.' -f parseable -r n -i y ' .
+	\ shellescape(expand('%')) .
+	\ ' 2>&1 \| sed ''s_: \[\([RCW]\)_: \[W] \[\1_''' .
+	\ ' \| sed ''s_: \[\([FE]\)_:\ \[E] \[\1_'''
     let errorformat = '%f:%l: [%t] %m,%Z,%-GNo config %m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction

--- a/syntax_checkers/python/python.vim
+++ b/syntax_checkers/python/python.vim
@@ -11,7 +11,8 @@
 function! SyntaxCheckers_python_GetLocList()
     let l:path = shellescape(expand('%'))
     let l:cmd = "compile(open(" . l:path . ").read(), " . l:path . ", 'exec')"
-    let l:makeprg = 'python -c "' . l:cmd . '"'
+    let l:makeprg = SyntasticCheckerCommand('python', 'interpreter', 'python -c') 
+	\ . ' "' . l:cmd . '"'
 
     let l:errorformat =
         \ "\%A\ \ File\ \"%f\"\\\,\ line\ %l\\\,%m," .


### PR DESCRIPTION
Hi,

For now all checkers are hardcoded in the plugin. Like here:

```
let makeprg = 'jshint ' . shellescape(expand("%")) . args
```

I.e. jshint can be only one and must be accessible with system PATH variable. It's not so easy to use another path/version/wrapper, that more suitable for my environment.

I propose to make this "jshint" more configurable, and give to user ability to change command of any checker if necessary, using one line in vimrc:

```
let g:syntastic_javascript_jshint_cmd = '/path/to/jshint --custom-options'
```

For that we need to adjust first line above to this form:

```
let makeprg = SyntasticCheckerCommand('javascript', 'jshint')  . shellescape(expand("%")) . args
```

I did it already for all Python checkers and for JS partially (as example).
For details please see comment for SyntasticCheckerCommand in the patch.

Thanks

P.S. Seems that patch can also solve problem #423 and maybe some similar.
