### PR TITLE
Efm perl: few fixed

### DIFF
--- a/syntax_checkers/efm_perl.pl
+++ b/syntax_checkers/efm_perl.pl
@@ -68,6 +68,7 @@
 use warnings;
 use strict;
 use Getopt::Std;
+use File::Temp qw( tempfile );
 
 use vars qw/$opt_I $opt_c $opt_w $opt_f $opt_h/; # needed for Getopt in combination with use strict 'vars'
 
@@ -91,6 +92,13 @@ my $handle = (defined $opt_f ? \*FILE : \*STDOUT);
 (my $file = shift) or &usage; # display usage if no filename is supplied
 my $args = (@ARGV ? ' ' . join ' ', @ARGV : '');
 
+if ($file eq '-') { # make STDIN seek-able, so it can be read twice
+    my $fh = tempfile();
+    print {$fh} <STDIN>;
+    open \*STDIN, '<&', $fh or die "open: $!";
+    seek \*STDIN, 0, 0 or die "seek: $!";
+}
+
 my $libs = join ' ', map {"-I$_"} split ',', $opt_I || '';
 my @error_lines = `perl $libs @{[defined $opt_c ? '-c ' : '' ]} @{[defined $opt_w ? '-X ' : '-Mwarnings ']} "$file$args" 2>&1`;
 
@@ -98,6 +106,9 @@ my @lines = map { "E:$_" } @error_lines;
 
 my @warn_lines;
 if(defined($opt_w)) {
+    if ($file eq '-') {
+        seek \*STDIN, 0, 0 or die "seek: $!";
+    }
     @warn_lines = `perl $libs @{[defined $opt_c ? '-c ' : '' ]} -Mwarnings "$file$args" 2>&1`;
 }
 


### PR DESCRIPTION
Trivial fix for uninitialized warning and more complicated fix for checking stdin.

Current version of efm_perl run perl twice to check separately for errors and warnings, and while checking stdin this result in first perl read stdin up to EOF, and second perl unable to check because stdin already at EOF. In most cases stdin will be a pipe, so it's not seek-able, and we've to make it seek-able to be able to feed second perl with same contents.
