### PR TITLE
Ignore tidy warning about <input> tags with type="search"

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -34,7 +34,8 @@ let s:ignore_html_errors = [
                 \ "<meta> proprietary attribute \"charset\"",
                 \ "<meta> lacks \"content\" attribute",
                 \ "inserting \"type\" attribute",
-                \ "proprietary attribute \"data-"
+                \ "proprietary attribute \"data-",
+                \ "<input> attribute \"type\" has invalid value \"search\""
                 \]
 
 function! s:ValidateError(text)


### PR DESCRIPTION
This is valid html5:

http://www.w3.org/TR/html-markup/input.search.html

There are several other HTML5 input types which may not pass tidy, this one particularly bugged me though.
