### PR TITLE
Use scala compiler, not interpreter, for syntax checking

### DIFF
--- a/syntax_checkers/scala.vim
+++ b/syntax_checkers/scala.vim
@@ -11,7 +11,7 @@
 "============================================================================
 
 "bail if the user doesnt have the scala binary installed
-if !executable("scala")
+if !executable("scalac")
     finish
 endif
 
@@ -20,7 +20,7 @@ if !exists("g:syntastic_scala_options")
 endif
 
 function! SyntaxCheckers_scala_GetLocList()
-    let makeprg = 'scala '. g:syntastic_scala_options .' '.  shellescape(expand('%')) . ' /dev/null'
+    let makeprg = 'scalac -Ystop-after:parser '. g:syntastic_scala_options .' '.  shellescape(expand('%'))
 
     let errorformat = '%f\:%l: %trror: %m'
 


### PR DESCRIPTION
Using the scala compiler instead of the interpreter to check the syntax
means that an error will not be raised if there is a package
decleration.

Also, stopping the compiler after the parser stage stops errors being
raised when importing from other files in your project.
