### PR TITLE
Fixing puppet-lint syntax check when using syntastic_puppet_lint_arguments variable

### DIFF
--- a/syntax_checkers/puppet.vim
+++ b/syntax_checkers/puppet.vim
@@ -57,7 +57,7 @@ function! s:getPuppetLintErrors()
         let g:syntastic_puppet_lint_arguments = ''
     endif
 
-    let makeprg = 'puppet-lint --log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}" '.g:syntastic_puppet_lint_arguments.shellescape(expand('%'))
+    let makeprg = 'puppet-lint --log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}" '.g:syntastic_puppet_lint_arguments.' '.shellescape(expand('%'))
     let errorformat = '%t%*[a-zA-Z] %m at %f:%l'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype': 'Style' })
 endfunction


### PR DESCRIPTION
At the moment if you attempt to disable a puppet-lint check in your vimcrc file, for example:

let g:syntastic_puppet_lint_arguments = '--no-80chars-check'

The puppet-lint syntax checking stops working in vim completely. There is a missing space between the arguments and the shellescape.
