### PR TITLE
Support checker name as argument to :SyntasticCheck.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -103,8 +103,12 @@ if !exists("g:syntastic_loc_list_height")
     let g:syntastic_loc_list_height = 10
 endif
 
+function! s:CompleteCheckerName(argLead, cmdLine, cursorPos)
+    return join(s:FindCheckersForFt(&ft), "\n")
+endfunction
+
 command! SyntasticToggleMode call s:ToggleMode()
-command! -nargs=? SyntasticCheck call s:UpdateErrors(0, <f-args>) <bar> call s:Redraw()
+command! -nargs=? -complete=custom,s:CompleteCheckerName SyntasticCheck call s:UpdateErrors(0, <f-args>) <bar> call s:Redraw()
 command! Errors call s:ShowLocList()
 
 highlight link SyntasticError SpellBad


### PR DESCRIPTION
This resolves #443, allowing you to run an arbitrary checker by passing its name to the ":SyntasticCheck" command. Subsequent calls to the no-argument form of ":SyntasticCheck" switch back to the default checker.

The code jumps through a few hoops to try to avoid breaking existing checkers and to make sure it syntastic doesn't get "stuck" using the same checker for subsequent calls. Hopefully I'm not making it more complicated than it needs to be. Let me know if you have a better way.
