### PR TITLE
Force case-sensitive matching in syntastic#c#ReadConfig

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -101,7 +101,7 @@ function! syntastic#c#ReadConfig(file)
 
     let parameters = []
     for line in lines
-        let matches = matchlist(line, '^\s*-I\s*\(\S\+\)')
+        let matches = matchlist(line, '\C^\s*-I\s*\(\S\+\)')
         if matches != [] && matches[1] != ''
             " this one looks like an absolute path
             if match(matches[1], '^\%(/\|\a:\)') != -1


### PR DESCRIPTION
If there is a better way to do this, feel free to change. I was having an issue due to 'ignorecase' being enabled and trying to use "-include pch.h" in my config to make clang use PCH.
