### PR TITLE
Fix php mess detector in php

### DIFF
--- a/syntax_checkers/php.vim
+++ b/syntax_checkers/php.vim
@@ -89,8 +89,8 @@ endfunction
 function! s:GetPHPMDErrors()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'phpmd',
-                \ 'args': 'text ' . g:syntastic_phpmd_rules,
-                \ 'subchecker': 'phpcs' })
+                \ 'post_args': 'text ' . g:syntastic_phpmd_rules,
+                \ 'subchecker': 'phpmd' })
     let errorformat = '%E%f:%l%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype' : 'Style' })
 endfunction


### PR DESCRIPTION
PHP mess detector expects the filename as the first argument, followed
by the output format and the rules. To fix this, use the 'post_args' to
provide the arguments.
Also change the subchecker to 'phpmd' instead of 'phpcs'.
