### PR TITLE
Fixing the errors in the ycm files

### DIFF
--- a/syntax_checkers/c/ycm.vim
+++ b/syntax_checkers/c/ycm.vim
@@ -15,6 +15,10 @@ if exists("loaded_ycm_c_syntax_checker")
 endif
 let loaded_ycm_c_syntax_checker = 1
 
+function! SyntaxCheckers_c_ycm_IsAvailable()
+    return exists('g:loaded_youcompleteme')
+endfunction
+
 if !exists('g:loaded_youcompleteme')
     finish
 endif
@@ -23,3 +27,6 @@ function! SyntaxCheckers_c_GetLocList()
     return youcompleteme#CurrentFileDiagnostics()
 endfunction
 
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'ycm'})

--- a/syntax_checkers/cpp/ycm.vim
+++ b/syntax_checkers/cpp/ycm.vim
@@ -15,7 +15,7 @@ if exists("loaded_ycm_cpp_syntax_checker")
 endif
 let loaded_ycm_cpp_syntax_checker = 1
 
-function! SyntaxCheckers_objc_ycm_IsAvailable()
+function! SyntaxCheckers_cpp_ycm_IsAvailable()
     return exists('g:loaded_youcompleteme')
 endfunction
 


### PR DESCRIPTION
I noticed that the recent Syntastic changes do not correctly update the YCM Syntastic files to use the new API. 

I also noticed that with the new API changes, YCM is not the default checker if it's present. Previously, Syntastic would use YCM if it's present without user interaction. 

I hope that this change is not intentional. It makes little sense for the the gcc checker to run if YCM is installed since YCM has to compile the file no matter what to provide its main functionality. It always has the errors/warnings for the current file, and since it continuously compiles the file in the background, it always has a fresh version of the errors/warnings.

With the current Syntastic defaults, gcc is picked as the checker. This makes _both_ gcc and YCM compile the file; I don't see how that's in the user's best interest.

As a temporary workaround, I've made YCM add itself as the preferred checker through `g:syntastic_{ft}_checkers` user options. See here: https://github.com/Valloric/YouCompleteMe/blob/master/autoload/youcompleteme.vim#L62

This is not ideal. I'd love it if we could somehow resolve this so that the old behavior is preserved.
