### PR TITLE
Support checker name as argument to :SyntasticCheck

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -107,8 +107,21 @@ endif
 
 let s:registry = g:SyntasticRegistry.Instance()
 
+function! s:CompleteCheckerName(argLead, cmdLine, cursorPos)
+    let checker_names = []
+    let fts = substitute(&ft, '-', '_', 'g')
+    for ft in split(fts, '\.')
+        for checker in s:registry.availableCheckersFor(ft)
+            if index(checker_names, checker.name()) == -1
+                call add(checker_names, checker.name())
+            endif
+        endfor
+    endfor
+    return join(checker_names, "\n")
+endfunction
+
 command! SyntasticToggleMode call s:ToggleMode()
-command! -nargs=? SyntasticCheck call s:UpdateErrors(0, <f-args>) <bar> call s:Redraw()
+command! -nargs=? -complete=custom,s:CompleteCheckerName SyntasticCheck call s:UpdateErrors(0, <f-args>) <bar> call s:Redraw()
 command! Errors call s:ShowLocList()
 
 highlight link SyntasticError SpellBad


### PR DESCRIPTION
This resolves #443, allowing you to run an arbitrary checker by passing its name to the ":SyntasticCheck" command.

The code is similar to #451, but updated for the recent checkers refactor (and consequently much simpler and less hacky!)
