### PR TITLE
Allow full-line highlights

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -25,6 +25,10 @@ if !exists("g:syntastic_enable_signs")
     let g:syntastic_enable_signs = 1
 endif
 
+if !exists("g:syntastic_highlight_lines")
+    let g:syntastic_highlight_lines = 0
+endif
+
 if !exists("g:syntastic_error_symbol")
     let g:syntastic_error_symbol = '>>'
 endif
@@ -407,16 +411,21 @@ function! s:HighlightErrors()
             let force_callback = has_key(item, 'force_highlight_callback') && item['force_highlight_callback']
 
             let group = item['type'] == 'E' ? 'SyntasticError' : 'SyntasticWarning'
-            if get( item, 'col' ) && !force_callback
+            if g:syntastic_highlight_lines
                 let lastcol = col([item['lnum'], '$'])
-                let lcol = min([lastcol, item['col']])
-                call matchadd(group, '\%'.item['lnum'].'l\%'.lcol.'c')
+                call matchadd(group, '\%'.item['lnum'].'l\%1c.*\%'.lastcol.'c')
             else
+                if get( item, 'col' ) && !force_callback
+                    let lastcol = col([item['lnum'], '$'])
+                    let lcol = min([lastcol, item['col']])
+                    call matchadd(group, '\%'.item['lnum'].'l\%'.lcol.'c')
+                else
 
-                if exists("*SyntaxCheckers_". ft ."_GetHighlightRegex")
-                    let term = SyntaxCheckers_{ft}_GetHighlightRegex(item)
-                    if len(term) > 0
-                        call matchadd(group, '\%' . item['lnum'] . 'l' . term)
+                    if exists("*SyntaxCheckers_". ft ."_GetHighlightRegex")
+                        let term = SyntaxCheckers_{ft}_GetHighlightRegex(item)
+                        if len(term) > 0
+                            call matchadd(group, '\%' . item['lnum'] . 'l' . term)
+                        endif
                     endif
                 endif
             endif


### PR DESCRIPTION
I don't like signs (because even if they have no text, they seem to [force](http://vim.1045645.n5.nabble.com/Is-it-possible-to-hide-the-quot-sign-column-quot-td3214239.html) you to have a `SignColumn`) and column-range specific highlights don't always work.

This rough commit tries to solve the problem by adding a new flag, `g:syntastic_highlight_lines`, which highlights the whole offending line (minus trailing newline).

I feel this is a rather heavy handed way to achieve this goal, but maybe it is actually the right way and should be merged. Even if it isn't, at least it shows precisely what behaviour I want but I don't think is available with syntastic as-is.
