### PR TITLE
re-add support for custom phpcs and phpmd options

### DIFF
--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -18,9 +18,13 @@ function! SyntaxCheckers_php_phpcs_IsAvailable()
 endfunction
 
 function! SyntaxCheckers_php_phpcs_GetLocList()
+    if !exists('g:syntastic_phpcs_conf')
+        let g:syntastic_phpcs_conf = ''
+    endif
+
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'phpcs',
-                \ 'args': '--report=csv',
+                \ 'args': g:syntastic_phpcs_conf . ' --report=csv',
                 \ 'subchecker': 'phpcs' })
     let errorformat = '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity,"%f"\,%l\,%c\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype': 'Style' })

--- a/syntax_checkers/php/phpmd.vim
+++ b/syntax_checkers/php/phpmd.vim
@@ -18,9 +18,13 @@ function! SyntaxCheckers_php_phpmd_IsAvailable()
 endfunction
 
 function! SyntaxCheckers_php_phpmd_GetLocList()
+    if !exists('g:syntastic_phpmd_rules')
+        let g:syntastic_phpmd_rules = 'codesize,design,unusedcode,naming'
+    endif
+
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'phpmd',
-                \ 'post_args': 'text  codesize,design,unusedcode,naming',
+                \ 'post_args': 'text ' . g:syntastic_phpmd_rules,
                 \ 'subchecker': 'phpmd' })
     let errorformat = '%E%f:%l%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype' : 'Style' })


### PR DESCRIPTION
It seems that in the recent split-up of the PHP syntax checker the support for custom phpcs and phpmd options was lost. This adds that support back in.
