### PR TITLE
Included some warning/errors to ignore

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -35,6 +35,11 @@ let s:ignore_html_errors = [
                 \ "<meta> lacks \"content\" attribute",
                 \ "inserting \"type\" attribute",
                 \ "proprietary attribute \"data-",
+                \ "missing <!DOCTYPE> declaration",
+                \ "inserting implicit <body>",
+                \ "inserting missing 'title' element",
+                \ "attribute \"[+",
+                \ "unescaped & or unknown entity",
                 \ "<input> attribute \"type\" has invalid value \"search\""
                 \]
 


### PR DESCRIPTION
These changes saved me from annoying html error/warning messages, maybe you are interested to include them

---

In today's html editing, almost nobody writes a "pure" html code
(complete, i mean), with body, title, etc... most of people uses CMS's
and similar things, which means that the html is just a "piece" of html
and not the entire structure, the changes on this branch are meant to
ignore those annoying warnings

The last line is for structures that includes the "&" character, like in
those kind of cases: < a href="http://foo.bar/something.php&value&something&foo" >
