### PR TITLE
Ruby checker breaks with rvm when using "system" ruby

### DIFF
--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -10,10 +10,6 @@
 "
 "============================================================================
 function! s:FindRubyExec()
-    if executable("rvm")
-        return system("rvm tools identifier")
-    endif
-
     return "ruby"
 endfunction
 


### PR DESCRIPTION
The MRI checker currently gets the version of ruby from RVM, if available, and then tries to call an executable with that name.  This breaks when the ruby version is "system" because there is no executable called that.

RVM should always have "ruby" set so simply using that should work.
