### PR TITLE
Add cp932(Windows-31J) support to tidy.vim.

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -21,6 +21,7 @@ function! s:TidyEncOptByFenc()
                 \'utf-16le'    : '-utf16le',
                 \'utf-16'      : '-utf16',
                 \'big5'        : '-big5',
+                \'cp932'       : '-shiftjis',
                 \'sjis'        : '-shiftjis',
                 \'cp850'       : '-ibm858',
                 \}

--- a/syntax_checkers/xhtml/tidy.vim
+++ b/syntax_checkers/xhtml/tidy.vim
@@ -26,6 +26,7 @@ function! s:TidyEncOptByFenc()
                 \'utf-16le'    : '-utf16le',
                 \'utf-16'      : '-utf16',
                 \'big5'        : '-big5',
+                \'cp932'       : '-shiftjis',
                 \'sjis'        : '-shiftjis',
                 \'cp850'       : '-ibm858',
                 \}


### PR DESCRIPTION
Tidy puts error when editing html file that encoded Shift JIS.
I added cp932 support to tidy.vim on html and xhtml.
cp932(Windows-31J) is Japanese vim user's Shift JIS. 
Further details about Windows-31J is [here](http://www.iana.org/assignments/character-sets/character-sets.xml)
