### PR TITLE
Remove sed(1) dependency from pylint

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -12,16 +12,18 @@ function! SyntaxCheckers_python_pylint_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'pylint',
                 \ 'args': ' -f parseable -r n -i y',
-                \ 'tail': s:MakeprgTail(),
                 \ 'subchecker': 'pylint' })
-    let errorformat = '%f:%l: [%t] %m,%Z,%-GNo config %m'
+    let errorformat = '%f:%l:%m,%Z,%-GNo config %m'
 
-    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
-endfunction
+    let loclist=SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 
-function! s:MakeprgTail()
-    return ' 2>&1 \| sed ''s_: \[\([RCW]\)_: \[W] \[\1_''' .
-         \ ' \| sed ''s_: \[\([FE]\)_:\ \[E] \[\1_'''
+    let n = len(loclist) - 1
+    while n >= 0
+        let loclist[n]['type'] = match(['R', 'C', 'W'], loclist[n]['text'][2]) > 0 ? 'W' : 'E'
+        let n -= 1
+    endwhile
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
The output from pylint can be munged in Vim, there's no need to rely on sed(1) for that.
