### PR TITLE
Phpmd conf

### DIFF
--- a/syntax_checkers/php/phpmd.vim
+++ b/syntax_checkers/php/phpmd.vim
@@ -13,8 +13,8 @@
 " See here for details of phpmd
 "   - phpmd (see http://phpmd.org)
 
-if !exists("g:syntastic_phpmd_conf")
-    let g:syntastic_phpmd_conf= "text  codesize,design,unusedcode,naming"
+if !exists("g:syntastic_phpmd_rulesets")
+    let g:syntastic_phpmd_rulesets = "codesize,design,unusedcode,naming"
 endif
 
 function! SyntaxCheckers_php_phpmd_IsAvailable()
@@ -24,7 +24,7 @@ endfunction
 function! SyntaxCheckers_php_phpmd_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'phpmd',
-                \ 'post_args': g:syntastic_phpmd_conf,
+                \ 'post_args': 'text ' . g:syntastic_phpmd_rulesets,
                 \ 'subchecker': 'phpmd' })
     let errorformat = '%E%f:%l%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'subtype' : 'Style' })


### PR DESCRIPTION
The ruleset which are used for phpmd should be configurable.. This changeset introduces the variable _syntastic_phpmd_rulesets_ to do just that.. :)

example:
let g:syntastic_phpmd_rulesets = "mercoline,codesize,naming"

thanks :)
