### PR TITLE
(Re)allow to disable vala syntax checker.

### DIFF
--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -23,7 +23,7 @@
 "============================================================================
 
 function! SyntaxCheckers_vala_valac_IsAvailable()
-    return executable('valac') || (exists('g:syntastic_vala_check_disabled') && g:syntastic_vala_check_disabled)
+    return executable('valac') && !(exists('g:syntastic_vala_check_disabled') && g:syntastic_vala_check_disabled)
 endfunction
 
 function! SyntaxCheckers_vala_valac_GetHighlightRegex(pos)


### PR DESCRIPTION
Since restructuring it was no longer possible to disable vala syntax checker. This trivial changes fix the regression.
