### PR TITLE
passing coffeelint options as argument to the executable

### DIFF
--- a/syntax_checkers/coffee/coffeelint.vim
+++ b/syntax_checkers/coffee/coffeelint.vim
@@ -20,7 +20,7 @@ endfunction
 function! SyntaxCheckers_coffee_coffeelint_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'coffeelint',
-                \ 'args': '--csv' })
+                \ 'args': '--csv '.g:syntastic_coffee_lint_options})
     let efm = '%f\,%l\,%trror\,%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': efm, 'subtype': 'Style' })
 endfunction


### PR DESCRIPTION
As I'm using a custom setup for coffeelint I've noticed that syntastic let you specify custom options but then it doesn't pass them to the executable.
This pull request adds the options to the list of arguments for the executable.

I'm no expert of VIM script so the fix is a bit simplistic.
