### PR TITLE
Don't pass -fno-code to Haskell's ghc

### DIFF
--- a/syntax_checkers/haskell/ghc-mod.vim
+++ b/syntax_checkers/haskell/ghc-mod.vim
@@ -11,7 +11,7 @@
 "============================================================================
 
 if !exists('g:syntastic_haskell_checker_args')
-    let g:syntastic_haskell_checker_args = '--ghcOpt="-fno-code" --hlintOpt="--language=XmlSyntax"'
+    let g:syntastic_haskell_checker_args = '--hlintOpt="--language=XmlSyntax"'
 endif
 
 function! SyntaxCheckers_haskell_ghc_mod_IsAvailable()


### PR DESCRIPTION
Passing `-fno-code` to GHC is meaningless since `ghc-mod check` doesn't generate code, and it actually prevents proper Haskell checking (such as `-Wall` and `-Werror`).
