### PR TITLE
Fix the "Missing :endfunction" in syntax_checkers\objc\gcc.vim

### DIFF
--- a/syntax_checkers/objc/gcc.vim
+++ b/syntax_checkers/objc/gcc.vim
@@ -77,7 +77,7 @@ endif
 
 function! SyntaxCheckers_objc_gcc_IsAvailable()
     return executable('gcc')
-endif
+endfunction
 
 function! SyntaxCheckers_objc_gcc_GetLocList()
     let makeprg = 'gcc -fsyntax-only -lobjc'


### PR DESCRIPTION
The ending statement of SyntaxCheckers_objc_gcc_IsAvailable was endif instead of endfunction. This caused a "Missing :endfunction" error.
