### PR TITLE
added possibility to change the perl interpreter.

### DIFF
--- a/syntax_checkers/perl/efm_perl.pl
+++ b/syntax_checkers/perl/efm_perl.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 # vimparse.pl - Reformats the error messages of the Perl interpreter for use
 # with the quickfix mode of Vim
 #
@@ -100,7 +100,7 @@ if ($file eq '-') { # make STDIN seek-able, so it can be read twice
 }
 
 my $libs = join ' ', map {"-I$_"} split ',', $opt_I || '';
-my @error_lines = `perl $libs @{[defined $opt_c ? '-c ' : '' ]} @{[defined $opt_w ? '-X ' : '-Mwarnings ']} "$file$args" 2>&1`;
+my @error_lines = `$^X $libs @{[defined $opt_c ? '-c ' : '' ]} @{[defined $opt_w ? '-X ' : '-Mwarnings ']} "$file$args" 2>&1`;
 
 my @lines = map { "E:$_" } @error_lines;
 
@@ -109,7 +109,7 @@ if(defined($opt_w)) {
     if ($file eq '-') {
         seek \*STDIN, 0, 0 or die "seek: $!";
     }
-    @warn_lines = `perl $libs @{[defined $opt_c ? '-c ' : '' ]} -Mwarnings "$file$args" 2>&1`;
+    @warn_lines = `$^X perl $libs @{[defined $opt_c ? '-c ' : '' ]} -Mwarnings "$file$args" 2>&1`;
 }
 
 # Any new errors must be warnings

--- a/syntax_checkers/perl/perl.vim
+++ b/syntax_checkers/perl/perl.vim
@@ -25,12 +25,16 @@
 "   let g:syntastic_perl_efm_program = "foo.pl -o -m -g"
 "
 
+if !exists("g:perl_interpreter")
+    let g:perl_interpreter = '/usr/bin/perl'
+endif
+
 function! SyntaxCheckers_perl_perl_IsAvailable()
-    return executable("perl")
+    return executable(g:perl_interpreter)
 endfunction
 
 if !exists("g:syntastic_perl_efm_program")
-    let g:syntastic_perl_efm_program = 'perl ' . shellescape(expand('<sfile>:p:h') . '/efm_perl.pl') . ' -c -w'
+    let g:syntastic_perl_efm_program = g:perl_interpreter . ' ' . shellescape(expand('<sfile>:p:h') . '/efm_perl.pl') . ' -c -w'
 endif
 
 function! SyntaxCheckers_perl_perl_GetLocList()


### PR DESCRIPTION
Hi,

this pull request allows the user to define a custom perl interpreter. 

This is needed if some uses perlbrew to manage perl installations in $HOME.

For example:

``` vim
" .vimrc
let g:perl_interpreter = '/Users/jan/perl5/perlbrew/perls/perl-5.14.2/bin/perl'
```
