### PR TITLE
ghd-mod.vim - Change the '-' (dash) in the "header guard" to a '_' (underscore) to fix an unexpected characters error.

### DIFF
--- a/syntax_checkers/haskell/ghc-mod.vim
+++ b/syntax_checkers/haskell/ghc-mod.vim
@@ -10,10 +10,10 @@
 "
 "============================================================================
 
-if exists("g:loaded_syntastic_haskell_ghc-mod_checker")
+if exists("g:loaded_syntastic_haskell_ghc_mod_checker")
     finish
 endif
-let g:loaded_syntastic_haskell_ghc-mod_checker=1
+let g:loaded_syntastic_haskell_ghc_mod_checker=1
 
 if !exists('g:syntastic_haskell_checker_args')
     let g:syntastic_haskell_checker_args = '--hlintOpt="--language=XmlSyntax"'


### PR DESCRIPTION
As the title mentions, I was getting an "unexpected character" error upon vim startup that had to do with this 
