### PR TITLE
Add highlight groups for the signs and the lines.

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -92,6 +92,30 @@ Syntastic uses the |:sign| commands to mark lines with errors and warnings in
 the sign column. To enable this feature, use the |'syntastic_enable_signs'|
 option.
 
+Signs are colored using the Error and Todo syntax highlight groups by default.
+If you wish to customize the colors for the signs, you can use the following
+groups:
+    SyntasticErrorSign - For syntax errors, links to 'error' by default
+    SyntasticWarningSign - For syntax warnings, links to 'todo' by default
+    SyntasticStyleErrorSign - For style errors, links to 'SyntasticErrorSign'
+                              by default
+    SyntasticStyleWarningSign - For style warnings, links to
+                                'SyntasticWarningSign' by default
+
+Example: >
+    highlight SyntasticErrorSign guifg=white guibg=red
+<
+To set up highlighting for the line where a sign resides, you can use the
+following highlight groups:
+    SyntasticErrorLine
+    SyntasticWarningLine
+    SyntasticStyleErrorLine - Links to 'SyntasticErrorLine' by default
+    SyntasticStyleWarningLine - Links to 'SyntasticWarningLine' by default
+
+Example: >
+    highlight SyntasticErrorLine guibg=#2f0000
+<
+
 ------------------------------------------------------------------------------
 2.3. The error window                       *:Errors* *syntastic-error-window*
 

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -274,10 +274,29 @@ endfunction
 
 if g:syntastic_enable_signs
     "define the signs used to display syntax and style errors/warns
-    exe 'sign define SyntasticError text='.g:syntastic_error_symbol.' texthl=error'
-    exe 'sign define SyntasticWarning text='.g:syntastic_warning_symbol.' texthl=todo'
-    exe 'sign define SyntasticStyleError text='.g:syntastic_style_error_symbol.' texthl=error'
-    exe 'sign define SyntasticStyleWarning text='.g:syntastic_style_warning_symbol.' texthl=todo'
+    exe 'sign define SyntasticError text='.g:syntastic_error_symbol.' texthl=SyntasticErrorSign linehl=SyntasticErrorLine'
+    exe 'sign define SyntasticWarning text='.g:syntastic_warning_symbol.' texthl=SyntasticWarningSign linehl=SyntasticWarningLine'
+    exe 'sign define SyntasticStyleError text='.g:syntastic_style_error_symbol.' texthl=SyntasticStyleErrorSign linehl=SyntasticStyleErrorLine'
+    exe 'sign define SyntasticStyleWarning text='.g:syntastic_style_warning_symbol.' texthl=SyntasticStyleWarningSign linehl=SyntasticStyleWarningLine'
+
+    if !hlexists('SyntasticErrorSign')
+        highlight link SyntasticErrorSign error
+    endif
+    if !hlexists('SyntasticWarningSign')
+        highlight link SyntasticWarningSign todo
+    endif
+    if !hlexists('SyntasticStyleErrorSign')
+        highlight link SyntasticStyleErrorSign SyntasticErrorSign
+    endif
+    if !hlexists('SyntasticStyleWarningSign')
+        highlight link SyntasticStyleWarningSign SyntasticWarningSign
+    endif
+    if !hlexists('SyntasticStyleErrorLine')
+        highlight link SyntasticStyleErrorLine SyntasticErrorLine
+    endif
+    if !hlexists('SyntasticStyleWarningLine')
+        highlight link SyntasticStyleWarningLine SyntasticWarningLine
+    endif
 endif
 
 "start counting sign ids at 5000, start here to hopefully avoid conflicting


### PR DESCRIPTION
This allows users to customize the coloring of Syntastic's signs, and
also provides them a way to highlight the entire line using :sign's
linehl feature.  It preserves the current default behavior of using
the error and todo highlight groups if the customized ones aren't
present.  If the linehl group doesn't exist, then it's the same as not
specifying one, so no special highlighting for the line will occur.
