### PR TITLE
Make.vim - Check g:syntastic_c_errorformat so that users can provide their own error format

### DIFF
--- a/syntax_checkers/c/make.vim
+++ b/syntax_checkers/c/make.vim
@@ -33,6 +33,10 @@ function! SyntaxCheckers_c_make_GetLocList()
         \ '%tarning: %m,%f:%l:%c: %m,%f:%l: %trror: %m,'.
         \ '%f:%l: %tarning: %m,%f:%l: %m'
 
+    if exists('g:syntastic_c_errorformat')
+        let errorformat = g:syntastic_c_errorformat
+    endif
+
     " process makeprg
     let errors = SyntasticMake({ 'makeprg': makeprg,
         \ 'errorformat': errorformat })


### PR DESCRIPTION
As the title says, allow the user to specify an error format in case they're using a compiler that reports differently than gcc.
