### PR TITLE
remove unused function (because of 2519d83)

### DIFF
--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -15,12 +15,8 @@ if exists("g:loaded_syntastic_ruby_mri_checker")
 endif
 let g:loaded_syntastic_ruby_mri_checker=1
 
-function! s:FindRubyExec()
-    return "ruby"
-endfunction
-
 if !exists("g:syntastic_ruby_exec")
-    let g:syntastic_ruby_exec = s:FindRubyExec()
+    let g:syntastic_ruby_exec = "ruby"
 endif
 
 function! SyntaxCheckers_ruby_mri_IsAvailable()


### PR DESCRIPTION
This works for me (tested with a ruby file that has errors)
