### PR TITLE
Made SyntacticIsVersionAtLeast more robust

### DIFF
--- a/autoload/syntastic/util.vim
+++ b/autoload/syntastic/util.vim
@@ -37,6 +37,37 @@ function! syntastic#util#ParseShebang()
     return {'exe': '', 'args': []}
 endfunction
 
+" Verify that the 'installed' version is at the 'required' version, if not
+" better.
+"
+" 'installed' and 'required' must be arrays.  Only the
+" first three elements (major, minor, patch) are looked at.
+"
+" Either array may be less than three elements. The "missing" elements
+" will be assumed to be '0' for the purposes of checking.
+"
+" See http://semver.org for info about version numbers.
+function syntastic#util#versionIsAtLeast(installed, required)
+    for index in [0,1,2]
+        if len(a:installed) <= index
+            let installed_element = 0
+        else
+            let installed_element = a:installed[index]
+        endif
+        if len(a:required) <= index
+            let required_element = 0
+        else
+            let required_element = a:required[index]
+        endif
+        if installed_element != required_element
+            return installed_element > required_element
+        endif
+    endfor
+    " Everything matched, so it is at least the required version.
+    return 1
+endfunction
+
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 " vim: set et sts=4 sw=4:

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -509,36 +509,6 @@ function! s:uname()
     return s:uname
 endfunction
 
-" Verify that the 'installed' version is at the 'required' version, if not
-" better.
-"
-" 'installed' and 'required' must be arrays.  Only the
-" first three elements (major, minor, patch) are looked at.
-"
-" Either array may be less than three elements. The "missing" elements
-" will be assumed to be '0' for the purposes of checking.
-"
-" See http://semver.org for info about version numbers.
-function SyntasticIsVersionAtLeast(installed, required)
-    for index in [0,1,2]
-        if len(a:installed) <= index
-            let installed_element = 0
-        else
-            let installed_element = a:installed[index]
-        endif
-        if len(a:required) <= index
-            let required_element = 0
-        else
-            let required_element = a:required[index]
-        endif
-        if installed_element != required_element
-            return installed_element > required_element
-        endif
-    endfor
-    " Everything matched, so it is at least the required version.
-    return 1
-endfunction
-
 "return a string representing the state of buffer according to
 "g:syntastic_stl_format
 "

--- a/syntax_checkers/puppet/puppetlint.vim
+++ b/syntax_checkers/puppet/puppetlint.vim
@@ -51,7 +51,7 @@ function! s:PuppetLintVersion()
 endfunction
 
 if !g:syntastic_puppet_lint_disable
-    if !SyntasticIsVersionAtLeast(s:PuppetLintVersion(), [0,1,10])
+    if !syntastic#util#versionIsAtLeast(s:PuppetLintVersion(), [0,1,10])
         let g:syntastic_puppet_lint_disable = 1
     endif
 end
@@ -68,7 +68,7 @@ endfunction
 
 function! s:getPuppetMakeprg()
     "If puppet is >= version 2.7 then use the new executable
-    if SyntasticIsVersionAtLeast(s:PuppetVersion(), [2,7,0])
+    if syntastic#util#versionIsAtLeast(s:PuppetVersion(), [2,7,0])
         let makeprg = 'puppet parser validate ' .
                     \ shellescape(expand('%')) .
                     \ ' --color=false'
@@ -86,7 +86,7 @@ function! s:getPuppetEfm()
 
     "Puppet 3.0.0 changes this from "err:" to "Error:"
     "reset errorformat in that case
-    if SyntasticIsVersionAtLeast(s:PuppetVersion(), [3,0,0])
+    if syntastic#util#versionIsAtLeast(s:PuppetVersion(), [3,0,0])
         let errorformat = '%-GError: Try ''puppet help parser validate'' for usage,'
         let errorformat .= 'Error: Could not parse for environment %*[a-z]: %m at %f:%l'
     endif

--- a/syntax_checkers/slim/slimrb.vim
+++ b/syntax_checkers/slim/slimrb.vim
@@ -33,7 +33,7 @@ function! SyntaxCheckers_slim_slimrb_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'slimrb',
                 \ 'args': '-c' })
-    if SyntasticIsVersionAtLeast(s:SlimrbVersion(), [1,3,1])
+    if syntastic#util#versionIsAtLeast(s:SlimrbVersion(), [1,3,1])
         let errorformat = '%C\ %#%f\, Line %l\, Column %c,%-G\ %.%#,%ESlim::Parser::SyntaxError: %m,%+C%.%#'
     else
         let errorformat = '%C\ %#%f\, Line %l,%-G\ %.%#,%ESlim::Parser::SyntaxError: %m,%+C%.%#'


### PR DESCRIPTION
It now handles more cases, which will cause Syntastic to degrade better when
commands return weird versions (e.g. the command crashes).

This fixes some problems I was having with puppet files -- specifically
I think my `puppet` command was crashing or otherwise not emitting a
version string.
