### PR TITLE
Typo: Check for puppet-lint, not puppet

### DIFF
--- a/syntax_checkers/puppet/puppetlint.vim
+++ b/syntax_checkers/puppet/puppetlint.vim
@@ -16,7 +16,7 @@ endif
 let g:loaded_syntastic_puppet_puppetlint_checker=1
 
 function! SyntaxCheckers_puppet_puppetlint_IsAvailable()
-    return executable("puppet")
+    return executable("puppet-lint")
 endfunction
 
 if !exists("g:syntastic_puppet_validate_disable")


### PR DESCRIPTION
This was just a typo and prevents puppet syntax checking from working if
`puppet-lint` is installed but `puppet` isn't.

`puppet` isn't needed for `puppet-lint` to work, assuming we're talking
about [rodjek's `puppet-lint`](https://github.com/rodjek/puppet-lint/)

And, no, I don't particularly like puppet; but syntastic makes working
with puppet much much easier.
