### PR TITLE
Work with copy of g:syntastic_vala_modules list.

### DIFF
--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -36,7 +36,7 @@ function! s:GetValaModules()
         if type(g:syntastic_vala_modules) == type('')
             return split(g:syntastic_vala_modules, '\s\+')
         elseif type(g:syntastic_vala_modules) == type([])
-            return g:syntastic_vala_modules
+            return copy(g:syntastic_vala_modules)
         else
             echoerr 'g:syntastic_vala_modules must be either list or string: fallback to in file modules string'
         endif


### PR DESCRIPTION
Pass a copy if g:syntastic_vala_modules is a list to not modify it.

g:syntastic_vala_modules = ['gtk+-3.0'] resulted in ['--pkg gtk+-3.0'] with the second run of the check.
