### PR TITLE
Use redraw in mvim

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -495,7 +495,7 @@ endfunction
 "However, on some versions of gvim using `redraw!` causes the screen to
 "flicker - so use redraw.
 function! s:Redraw()
-    if has('gui_running')
+    if has('gui_running') || has('gui_macvim')
         redraw
     else
         redraw!


### PR DESCRIPTION
I have been facing the flicker issue in mvim (especially when using YouCompleteMe w/ syntastic). Using redraw instead of redraw! fixes it. If you want to add it as config option, I can provide that too.
