### PR TITLE
flake8 2.0 error parsing

### DIFF
--- a/syntax_checkers/python/flake8.vim
+++ b/syntax_checkers/python/flake8.vim
@@ -34,7 +34,11 @@ function! SyntaxCheckers_python_flake8_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'flake8',
                 \ 'subchecker': 'flake8' })
-    let errorformat = '%E%f:%l: could not compile,%-Z%p^,%E%f:%l:%c: %t%n %m,%E%f:%l: %t%n %m,%-G%.%#'
+    let errorformat = '%E%f:%l: could not compile,%-Z%p^,'.
+            \'%W%f:%l:%c: F%n %m,'.
+            \'%W%f:%l:%c: C%n %m,'.
+            \'%E%f:%l:%c: %t%n %m,'.
+            \'%E%f:%l: %t%n %m,%-G%.%#'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction
 


### PR DESCRIPTION
Flake 8 has recently (2013-02-23) been upgraded to Version 2.0, and they
changed their message output:

> Pyflakes errors are prefixed by an F instead of an E
> McCabe complexity warnings are prefixed by a C instead of a W

This change fixes the errorformat to account for that.
