### PR TITLE
Add support for JSHint's secondary error format

### DIFF
--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -30,7 +30,7 @@ function! SyntaxCheckers_javascript_jshint_GetLocList()
                 \ 'post_args': ' --verbose ' . s:Args(),
                 \ 'subchecker': 'jshint' })
 
-    let errorformat = '%f: line %l\, col %c\, %m. \(%t%*\d\)'
+    let errorformat = '%f: line %l\, col %c\, %m \(%t%*\d\)'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'defaults': {'bufnr': bufnr('')} })
 endfunction
 


### PR DESCRIPTION
JSHint has a secondary error format that includes a number related to the error message.

E.g. The normal error format is something like: 

.\Foo.js: line 2, col 5, Missing semicolon. (W033)

But the secondary error format includes a number in parentheses:

.\Foo.js: line 3, col 4, Blocks are nested too deeply. (2) (W073)

I've changed the errorformat to read the message until it hits a space, instead of a period, so that these errors are included.
