### PR TITLE
Error on SyntasticToggleMode.

### DIFF
--- a/plugin/syntastic/modemap.vim
+++ b/plugin/syntastic/modemap.vim
@@ -30,9 +30,9 @@ endfunction
 
 function! g:SyntasticModeMap.toggleMode()
     if self._mode == "active"
-        self._mode = "passive"
+        let self._mode = "passive"
     else
-        self._mode = "active"
+        let self._mode = "active"
     endif
 endfunction
 


### PR DESCRIPTION
When executing ':SyntasticToggleMode', following error was occured.

```
Error detected while processing function <SNR>36_ToggleMode..53:
line    2:
E492: Not an editor command:         self._mode = "passive"
```
