### PR TITLE
Fixes the sparse checker.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -262,7 +262,7 @@ function! s:HighlightErrors()
             elseif get(item, 'col')
                 let lastcol = col([item['lnum'], '$'])
                 let lcol = min([lastcol, item['col']])
-                call matchadd(group, '\%'.item['lnum'].'l\%'.lcol.'c')
+                call matchadd(group, '\%'.item['lnum'].'l\%'.lcol.(item['vcol'] ? 'v' : 'c'))
             endif
         endfor
     endfor

--- a/syntax_checkers/c/sparse.vim
+++ b/syntax_checkers/c/sparse.vim
@@ -1,6 +1,6 @@
 "============================================================================
 "File:        sparse.vim
-"Description: Syntax checking plugin for syntastic.vim using sparse.pl 
+"Description: Syntax checking plugin for syntastic.vim using sparse.pl
 "Maintainer:  Daniel Walker <dwalker at fifo99 dot com>
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
@@ -8,6 +8,14 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
+"
+" The setting 'g:syntastic_sparse_config_file' allows you to define a file
+" that contains additional compiler arguments like include directories or
+" CFLAGS. The file is expected to contain one option per line. If none is
+" given the filename defaults to '.syntastic_sparse_config':
+"
+"   let g:syntastic_sparse_config_file = '.config'
+
 if exists("loaded_sparse_syntax_checker")
     finish
 endif
@@ -17,13 +25,17 @@ function! SyntaxCheckers_c_sparse_IsAvailable()
     return executable("sparse")
 endfunction
 
+if !exists('g:syntastic_sparse_config_file')
+    let g:syntastic_sparse_config_file = '.syntastic_sparse_config'
+endif
+
 function! SyntaxCheckers_c_sparse_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'sparse',
-                \ 'args': syntastic#c#ReadConfig(g:syntastic_sparse_config_file) })
-                \ 'subchecker': ':parse' })
+                \ 'args': syntastic#c#ReadConfig(g:syntastic_sparse_config_file),
+                \ 'subchecker': 'sparse' })
 
-    let errorformat = '%f:%l:%c: %trror: %m,%f:%l:%c: %tarning: %m,'
+    let errorformat = '%f:%l:%v: %trror: %m,%f:%l:%v: %tarning: %m,'
 
     let loclist = SyntasticMake({ 'makeprg': makeprg,
                                 \ 'errorformat': errorformat,


### PR DESCRIPTION
The sparse checker has been broken for a while.
Also, syntax highlighting was off if `errorformat` contained `%v`.
