### PR TITLE
update the default coffeescript checker

### DIFF
--- a/syntax_checkers/coffee/coffee.vim
+++ b/syntax_checkers/coffee/coffee.vim
@@ -21,7 +21,7 @@ endfunction
 function! SyntaxCheckers_coffee_coffee_GetLocList()
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'coffee',
-                \ 'args': '-c -l -o /tmp',
+                \ 'args': '--lint',
                 \ 'subchecker': 'coffee' })
     let errorformat = '%E%f:%l:%c: %trror: %m,' .
                 \ 'Syntax%trror: In %f\, %m on line %l,' .


### PR DESCRIPTION
No need to generate a file when linting, as the coffeescript compiler
will do that for you.

This has been tested with coffeescript 1.6.2.

Also: use options over flags for readibility
