### PR TITLE
Add support for nested dirs inside src/

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -1,18 +1,34 @@
 #!/usr/bin/env escript
 -export([main/1]).
 
-main([FileName| LibDirs=[_|_]]) ->
-    code:add_pathsa(LibDirs),
-    main([FileName]);
-
 main([FileName]) ->
+    LibDirs = filelib:wildcard("{lib,deps}/*/ebin"),
+    compile(FileName, LibDirs);
+main([FileName | LibDirs]) ->
+    compile(FileName, LibDirs).
+
+compile(FileName, LibDirs) ->
+    Root = get_root(filename:dirname(FileName)),
+    ok = code:add_pathsa(LibDirs),
     compile:file(FileName, [warn_obsolete_guard,
                             warn_unused_import,
                             warn_shadow_vars,
                             warn_export_vars,
                             strong_validation,
                             report,
-                            {i, filename:dirname(FileName) ++ "/../include"},
-                            {i, filename:dirname(FileName) ++ "/../deps"},
-                            {i, filename:dirname(FileName) ++ "/../../../deps"}
+                            {i, filename:join(Root, "include")},
+                            {i, filename:join(Root, "deps")},
+                            {i, filename:join(Root, "apps")},
+                            {i, filename:join(Root, "lib")}
                         ]).
+
+get_root(Dir) ->
+    Path = filename:split(filename:absname(Dir)),
+    filename:join(get_root(lists:reverse(Path), Path)).
+
+get_root([], Path) ->
+    Path;
+get_root(["src" | Tail], _Path) ->
+    lists:reverse(Tail);
+get_root([_ | Tail], Path) ->
+    get_root(Tail, Path).


### PR DESCRIPTION
When having nested directories (for instance `src/protocol/tm_protocol.erl`)
autocompilation would fail. 

This patch does:
- Finds all `ebin/` directories and adds them to path
- Looks up the application root and uses that as base for compiler include path.

This should now work regardless of dependency structure (Rebar or OTP) and adds additional support for multi-app projects.
