### PR TITLE
Better fix for #624

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -220,19 +220,6 @@ Enable this option if you want the cursor to jump to the first detected error
 when saving or opening a file: >
     let g:syntastic_auto_jump=1
 <
-
-                                                      *'syntastic_allow_quit'*
-Default: 1
-When the |location-list| is open and you quit a buffer, syntastic attempts to
-detect if this is the last active buffer, and quit Vim if it is.  This is
-usually what you want, but in that situation Vim will also abandon any hidden
-buffers, thus potentially destroying a carefully crafted session.  Use this
-variable to prevent syntastic from quitting Vim.
-
-When |syntastic_allow_quit| is 0 syntastic will never issue a 'quit' command: >
-    let g:syntastic_allow_quit=0
-<
-
                                                    *'syntastic_auto_loc_list'*
 Default: 2
 Use this option to tell syntastic to automatically open and/or close the

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -40,10 +40,6 @@ if !exists("g:syntastic_check_on_open")
     let g:syntastic_check_on_open = 0
 endif
 
-if !exists("g:syntastic_allow_quit")
-    let g:syntastic_allow_quit = 1
-endif
-
 if !exists("g:syntastic_loc_list_height")
     let g:syntastic_loc_list_height = 10
 endif
@@ -79,8 +75,8 @@ augroup syntastic
     " TODO: the next autocmd should be "autocmd BufWinLeave * if empty(&bt) | lclose | endif"
     " but in recent versions of Vim lclose can no longer be called from BufWinLeave
     autocmd BufEnter * call s:BufWinLeaveCleanup()
+    autocmd QuitPre * call s:QuitCleanup()
 augroup END
-
 
 function! s:BufWinLeaveCleanup()
     " TODO: at this point there is no b:syntastic_loclist
@@ -89,6 +85,15 @@ function! s:BufWinLeaveCleanup()
     if &bt=='quickfix' && !empty(loclist) && empty(filter( buffers, 'syntastic#util#bufIsActive(v:val)' ))
         call g:SyntasticLoclistHide()
     endif
+endfunction
+
+function s:QuitCleanup()
+    try
+        lclose 
+    catch /^Vim\%((\a\+)\)\=:E444/
+        " the loclist is the last open window, it will be closed automatically
+        " by vim, so we do nothing
+    endtry
 endfunction
 
 "refresh and redraw all the error info for this buf when saving or reading

--- a/plugin/syntastic/loclist.vim
+++ b/plugin/syntastic/loclist.vim
@@ -146,13 +146,13 @@ endfunction
 " Non-method functions {{{1
 
 function! g:SyntasticLoclistHide()
-    if len(filter( range(1, bufnr('$')), 'syntastic#util#bufIsActive(v:val)' )) == 1
-        if g:syntastic_allow_quit
-            quit
-        endif
-    else
+    try
         lclose
-    endif
+    catch /^Vim\%((\a\+)\)\=:E444/
+        " The location list is the last window, we cannot close it. This function is called in BufEnter
+        " which means we cannot use buffer manipulation commands like bdel and
+        " bnext either, so we do nothing.
+    endtry
 endfunction
 
 " vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Never issue an automatic :quit as with hidden buffers, this can
destroy the user's session. Instead use the QuitPre autocmd. Also,
silence the error when trying to autohide the loc list and it is the
last window.
