### PR TITLE
Add autopep8 for python

### DIFF
--- a/syntax_checkers/python/autopep8.vim
+++ b/syntax_checkers/python/autopep8.vim
@@ -9,14 +9,22 @@ if exists("g:loaded_syntastic_python_autopep8_checker")
 endif
 let g:loaded_syntastic_python_autopep8_checker=1
 
+if !exists('g:syntastic_autopep8_agressive')
+    let g:syntastic_autopep8_agressive = 0
+endif
+
 function! SyntaxCheckers_python_autopep8_IsAvailable()
     return executable('autopep8')
 endfunction
 
 function! SyntaxCheckers_python_autopep8_GetLocList()
+    let args = ' --in-place --jobs=0'
+    if g:syntastic_autopep8_agressive
+        let args = args.' --aggressive'
+    endif
     let makeprg = syntastic#makeprg#build({
                 \ 'exe': 'autopep8',
-                \ 'args': ' --in-place --aggressive --jobs=0',
+                \ 'args': args ,
                 \ 'subchecker': 'autopep8' })
     let errorformat = '%m'
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
https://github.com/hhatto/autopep8

A tool that automatically formats Python code to conform to the PEP 8 style guide.

Put it before other checkers to fix style first:

``` vim
let g:syntastic_python_checkers = ['autopep8', 'py3kwarn', 'flake8', ]
```
