### PR TITLE
Add default checker for javascript

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -9,6 +9,7 @@ let s:defaultCheckers = {
         \ 'cpp': ['gcc'],
         \ 'html': ['tidy'],
         \ 'java': ['javac'],
+        \ 'javascript': ['jslint', 'jshint'],
         \ 'objc': ['gcc'],
         \ 'php': ['php', 'phpcs', 'phpmd'],
         \ 'ruby': ['mri']


### PR DESCRIPTION
Using JSHint as the JS checker throws the deprecation notice about available checkers
