### PR TITLE
Add main to list of block level elements

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -74,7 +74,7 @@ endfunction
 
 function s:Args()
     let args = s:TidyEncOptByFenc() .
-        \ ' --new-blocklevel-tags ' . shellescape('section, article, aside, hgroup, header, footer, nav, figure, figcaption') .
+        \ ' --new-blocklevel-tags ' . shellescape('main, section, article, aside, hgroup, header, footer, nav, figure, figcaption') .
         \ ' --new-inline-tags ' . shellescape('video, audio, source, embed, mark, progress, meter, time, ruby, rt, rp, canvas, command, details, datalist') .
         \ ' --new-empty-tags ' . shellescape('wbr, keygen') .
         \ ' -e'


### PR DESCRIPTION
HTML5 now supports main element http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-main-element
