### PR TITLE
Change coffee arg from -c to -t to prevent JS file pollution

### DIFF
--- a/syntax_checkers/coffee/coffee.vim
+++ b/syntax_checkers/coffee/coffee.vim
@@ -25,7 +25,7 @@ function! SyntaxCheckers_coffee_coffee_GetLocList()
     " Sadly, Vim doesn't have a function to create temporary directories.
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'coffee',
-        \ 'args': '-c',
+        \ 'args': '-t',
         \ 'filetype': 'coffee',
         \ 'subchecker': 'coffee' })
 


### PR DESCRIPTION
The -t flag will output tokens (and syntax errors if there are any) - it is quite a lot quicker than another alternative, -n, especially for large files.
