### PR TITLE
sh: do not enforce POSIX validation on bash/zsh scripts

### DIFF
--- a/syntax_checkers/sh/checkbashisms.vim
+++ b/syntax_checkers/sh/checkbashisms.vim
@@ -20,7 +20,7 @@ endfunction
 function! SyntaxCheckers_sh_checkbashisms_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'checkbashisms',
-        \ 'args': '-fpx',
+        \ 'args': '-fx',
         \ 'filetype': 'sh',
         \ 'subchecker': 'checkbashisms'})
 


### PR DESCRIPTION
The POSIX check warns about perfectly legal bash/zsh statements such as the 'local' keyword.
It's archaic and irrelevant nowadays.
