### PR TITLE
Syntastic: Added option for fortran include dirs

### DIFF
--- a/syntax_checkers/fortran/gfortran.vim
+++ b/syntax_checkers/fortran/gfortran.vim
@@ -9,12 +9,19 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "Note:        This syntax checker uses gfortran with the option -fsyntax-only
 "             to check for errors and warnings. Additional flags may be
-"             supplied through both local and global variables,
-"               b:syntastic_fortran_flags,
-"               g:syntastic_fortran_flags.
+"             supplied through both local and global variables:
+"
+"               b:syntastic_fortran_flags
+"               g:syntastic_fortran_flags
+"
+"             In addition, one may add custom include directories through the
+"             variable:
+"
+"               g:syntastic_fortran_include_dirs =  []
+"
 "             This is particularly useful when the source requires module files
-"             in order to compile (that is when it needs modules defined in
-"             separate files).
+"             in order to compile, that is, when it needs modules defined in
+"             separate files.
 "
 "============================================================================
 
@@ -25,6 +32,10 @@ let g:loaded_syntastic_fortran_gfortran_checker=1
 
 if !exists('g:syntastic_fortran_flags')
     let g:syntastic_fortran_flags = ''
+endif
+
+if !exists('g:syntastic_fortran_include_dirs')
+    let g:syntastic_fortran_include_dirs =  []
 endif
 
 function! SyntaxCheckers_fortran_gfortran_IsAvailable()
@@ -50,12 +61,17 @@ function! SyntaxCheckers_fortran_gfortran_GetLocList()
         \ 'errorformat': errorformat })
 endfunction
 
+function s:include_dirs(dirs)
+  let valid_dirs = filter(copy(a:dirs), 'isdirectory(v:val)')
+  return join(map(valid_dirs,'"-I" . v:val')," ")
+endfunction
+
 function s:args()
     let rv  = '-fsyntax-only ' . g:syntastic_fortran_flags
     if exists('b:syntastic_fortran_flags')
         let rv .= " " . b:syntastic_fortran_flags
     endif
-    return rv
+    return rv . " " . s:include_dirs(g:syntastic_fortran_include_dirs)
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
New option added, default value:
g:syntastic_fortran_include_dirs = []

The option g:syntastic_fortran_include_dirs is a list of directories that may contain module and object files.  When one keeps modules in separate files, which is relatively normal for fortran projects, the module and/or object files must be available to the compiler.  This can now be done by adding the directories that should be included to this list.

The idea behind this update is not mine: It came from Sergio Losilla, who sent me a patch with the basic structure of the update. I made some minor changes and improvements upon his work.
