### PR TITLE
Make syntastic haxe makeprg "vaxe" aware

### DIFF
--- a/syntax_checkers/haxe/haxe.vim
+++ b/syntax_checkers/haxe/haxe.vim
@@ -44,7 +44,13 @@ function! s:FindInParent(fln,flsrt,flstp)
 endfunction
 
 function! SyntaxCheckers_haxe_haxe_GetLocList()
-    let [success, hxmldir, hxmlname] = s:FindInParent('*.hxml', expand('%:p:h'), '/')
+    if exists('b:vaxe_hxml')
+        let hxmlname = b:vaxe_hxml
+        let hxmldir = fnamemodify(b:vaxe_hxml, ':p:h')
+        let success = 'ok'
+    else
+        let [success, hxmldir, hxmlname] = s:FindInParent('*.hxml', expand('%:p:h'), '/')
+    endif
     if success == 'ok'
         let makeprg = syntastic#makeprg#build({
             \ 'exe': 'haxe',


### PR DESCRIPTION
I'm the author of a plugin for haxe that provides typical features, including build management.  It would be nice if syntastic would use the specified build file that is selected via vaxe, rather than defaulting to the first one it finds.
