### PR TITLE
Add pyflakes to the default checkers.

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -18,7 +18,7 @@ let s:defaultCheckers = {
         \ 'perl':       ['perl', 'perlcritic'],
         \ 'php':        ['php', 'phpcs', 'phpmd'],
         \ 'puppet':     ['puppet', 'puppetlint'],
-        \ 'python':     ['python', 'flake8', 'pylint'],
+        \ 'python':     ['python', 'pyflakes', 'flake8', 'pylint'],
         \ 'ruby':       ['mri'],
         \ 'sh':         ['sh'],
         \ 'tex':        ['lacheck']


### PR DESCRIPTION
Since bad592ece864f2a5c253efc01fcd9752ae9a5b76 (the hash says it all) `pyflakes` won't run, even when doing `let g:syntastic_python_syntax_checkers=["pyflakes"]` or `let g:syntastic_python_syntax_checker="pyflakes"` as it was before.

The real bug is that if the checker is not in `s:defaultCheckers`, it won't be used, even when forced in the user configuration. This means that `s:defaultCheckers` acts more like a whitelist than a defaults list.

This PR is a quick fix for `pyflakes` only because it's the one I needed. I don't use VimScript and I don't know the codebase so I would not now what to search for if I were to fix the root cause.
