### PR TITLE
Update --emacs flag to --format emacs for RuboCop

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -25,7 +25,7 @@ endfunction
 function! SyntaxCheckers_ruby_rubocop_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'rubocop',
-        \ 'args': '--emacs --silent',
+        \ 'args': '--format emacs --silent',
         \ 'filetype': 'ruby',
         \ 'subchecker': 'rubocop' })
 


### PR DESCRIPTION
The `--emacs` flag has been deprecated. Switch to specifying
`--format emacs` so that this doesn't break when RuboCop 1.0 is
released.
