### PR TITLE
Fix errorformat for RuboCop checker

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -29,7 +29,7 @@ function! SyntaxCheckers_ruby_rubocop_GetLocList()
         \ 'filetype': 'ruby',
         \ 'subchecker': 'rubocop' })
 
-    let errorformat = '%f:%l:\ %t:\ %m'
+    let errorformat = '%f:%l:%c:\ %t:\ %m'
 
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
The errorformat for the RuboCop checker was missing the capture group
for the column number of the error/warning, which resulted in the
location list attempting to jump to 'filename.rb:80', which would
attempt to open a new file rather than open the file at the particular line.

Add the "%c" to capture the column number of the
error.
