### PR TITLE
Go main redeclared

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -67,6 +67,10 @@ function! SyntaxCheckers_go_go_GetLocList()
         \ 'cwd': expand('%:p:h'),
         \ 'defaults': {'type': 'e'} })
 
+    " When two files in a directory are independent executables this causes
+    " a error saying: "main redeclared"
+    " While this is not realy an error, you can build both executables just
+    " fine in this dir. The loop below filters out there 'errors'.
     for e in errors
         if !empty(matchlist(e['text'] , 'main redeclared'))
             if match(expand('%'), '_test.go$') == -1


### PR DESCRIPTION
When two files in a directory are independent executables this causes
a error saying: "main redeclared"
While this is not realy an error, because you can build both executables just
fine in this directory. Added a bit to filter these 'errors' out of the error list.

Let me know what you think. 
Cheers
