### PR TITLE
Make ruby c header detection work with all ruby versions

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -199,7 +199,7 @@ function! syntastic#c#CheckRuby()
     if executable('ruby')
         if !exists('s:ruby_flags')
             let s:ruby_flags = system('ruby -r rbconfig -e '
-                        \ . '''puts Config::CONFIG["archdir"]''')
+                        \ . '''puts RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["archdir"]''')
             let s:ruby_flags = substitute(s:ruby_flags, "\n", '', '')
             let s:ruby_flags = ' -I' . s:ruby_flags
         endif


### PR DESCRIPTION
Ruby header file(ruby.h) finder for c syntax checker is not working for ruby version >=1.9.
Calling Config module causing warning in new ruby versions. That prevents syntastic from setting path properly and shows error on buff write.

```
/bin/bash: -c: line 0: unexpected EOF while looking for matching `''
/bin/bash: -c: line 1: syntax error: unexpected end of file

Error detected while processing function <SNR>79_UpdateErrors..<SNR>79_CacheErrors..201..SyntaxCheckers_c_gcc_GetLocList..SyntasticMake:
line   31:
E40: Can't open errorfile /var/folders/89/p35dmxwd1ll7b5hc7r9_k8z00000gn/T/vH8tc5u/3
E486: Pattern not found: Users
```

Underlying reason is in config command:

```
ruby -r rbconfig -e "puts Config::CONFIG['"archdir"']"                                                                                                ruby-2.0.0-p195
-e:1:in `<main>': Use RbConfig instead of obsolete and deprecated Config.
-e:1:in `<main>': Use RbConfig instead of obsolete and deprecated Config.
ruby-2.0.0-p195/lib/ruby/2.0.0/x86_64-darwin12.3.0
```

This patch also uses supports all ruby versions header path notation.

This pull request is more advanced version of https://github.com/scrooloose/syntastic/pull/403
