### PR TITLE
Add key mappings to the error window

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -24,6 +24,7 @@ CONTENTS                                                  *syntastic-contents*
         2.1.The statusline flag...............|syntastic-statusline-flag|
         2.2.Error signs.......................|syntastic-error-signs|
         2.3.Error window......................|syntastic-error-window|
+        2.4.Error window mappings.............|syntastic-mappings|
     3.Commands................................|syntastic-commands|
     4.Global Options..........................|syntastic-global-options|
     5.Checker Options.........................|syntastic-checker-options|
@@ -127,6 +128,16 @@ in the |location-list|.
 Note that when you use :Errors, the current location list is overwritten with
 Syntastic's own location list.
 
+------------------------------------------------------------------------------
+2.4. Error window mappings                                *syntastic-mappings*
+
+The following keyboard shortcuts are available in the error window:
+
+o             open file (same as enter)
+
+go            preview file (open but maintain focus in error window)
+
+q             close error window
 
 ==============================================================================
 3. Commands                                               *syntastic-commands*

--- a/plugin/syntastic/loclist.vim
+++ b/plugin/syntastic/loclist.vim
@@ -147,6 +147,14 @@ function! g:SyntasticLoclist.show()
     if self.hasErrorsOrWarningsToDisplay()
         let num = winnr()
         exec "lopen " . g:syntastic_loc_list_height
+
+        " Close error list
+        exec "nnoremap <silent> <buffer> q :call g:SyntasticLoclistHide()<CR>"
+        " Same as enter
+        exec "nnoremap <silent> <buffer> o <CR>"
+        " Jump to file/line, but keep focus in error list
+        exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
+
         if num != winnr()
             wincmd p
         endif


### PR DESCRIPTION
Add following key mappings to the error window:

q  - closes error window
o - open error(for those who does not use enter too much :sunglasses:)
go - shows error position but keeps focus in error window. Extremely handy when reviewing multiple errors.
