### PR TITLE
Add possibility to specify a rebar file as parameter in erlang_check_file.erl

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -4,6 +4,33 @@
 main([FileName]) ->
     LibDirs = filelib:wildcard("{lib,deps}/*/ebin"),
     compile(FileName, LibDirs);
+
+main([FileName | ["-rebar" | [Path | LibDirs]]]) ->
+    {ok, L} = file:consult(Path),
+    P = dict:from_list(L),
+    Root = filename:dirname(Path),
+
+    Lib1 = case dict:find(lib_dirs, P) of
+             {ok, X} -> lists:map(fun(Sub) -> Root ++ "/" ++ Sub end, X);
+             _ -> []
+           end,
+
+    Lib2 = case dict:find(sub_dirs, P) of
+             {ok, Y} -> lists:foldl(
+                          fun(Sub,Sofar) ->
+                              Sofar ++ [
+                                        Root ++ "/" ++ Sub,
+                                        Root ++ "/" ++ Sub ++ "/include",
+                                        Root ++ "/" ++ Sub ++ "/deps",
+                                        Root ++ "/" ++ Sub ++ "/lib"
+                                       ] end, [], Y);
+             _ -> []
+           end,
+
+    LibDirs1 = LibDirs ++ Lib1 ++ Lib2,
+    %io:format("~p~n", [LibDirs1]),
+    compile(FileName, LibDirs1);
+
 main([FileName | LibDirs]) ->
     compile(FileName, LibDirs).
 


### PR DESCRIPTION
I want to use lib_dirs and sub_dirs from rebar file and run compile with
this paths. So I search for the next rebar.config file and pass this in
g:syntastic_erlc_include_path.

Fixes: https://github.com/scrooloose/syntastic/issues/685
