### PR TITLE
Replace deprecated pylint option

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -16,7 +16,7 @@ endfunction
 function! SyntaxCheckers_python_pylint_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'pylint',
-        \ 'args': ' -f parseable -r n -i y',
+        \ 'args': ' --msg-template="{path}:{line}: [{msg_id}] {msg}" -r n',
         \ 'filetype': 'python',
         \ 'subchecker': 'pylint' })
 


### PR DESCRIPTION
"-f parseable" creates a deprecation warning that stops syntastic from
working. Replace this option with the equivalent in pylint 1.0.

This breaks compatibility with pylint versions < 1.0.
