### PR TITLE
PHP: Don't load any ini files

### DIFF
--- a/syntax_checkers/php/php.vim
+++ b/syntax_checkers/php/php.vim
@@ -30,7 +30,7 @@ endfunction
 function! SyntaxCheckers_php_php_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'php',
-        \ 'args': '-l -d error_reporting=E_ALL -d display_errors=1 -d log_errors=0 -d xdebug.cli_color=0',
+        \ 'args': '-n -l -d error_reporting=E_ALL -d display_errors=1 -d log_errors=0',
         \ 'filetype': 'php',
         \ 'subchecker': 'php' })
 


### PR DESCRIPTION
By not loading any ini files (`-n`), startup errors are prevented from occurring.

like this:

```
-> php -l -d error_reporting=E_ALL -d display_errors=0 -d error_log='' 'file.php'
PHP Warning:  Module 'redis' already loaded in Unknown on line 0
No syntax errors detected in file.php
```

The startup warning in the above example fools syntastic into thinking there are lint errors to process - this causes phpcs (and mess detector) checks to be skipped, yet as there's no actual lint error to display, nothing is displayed.

reference: @7fedd203e716c170efcf0c43a7e35406edef4aad (even though the code looks quite different now, and I can't trace where that logic is :))
