### PR TITLE
Coffeelint: Fixed errorformat, last line is optional

### DIFF
--- a/syntax_checkers/coffee/coffeelint.vim
+++ b/syntax_checkers/coffee/coffeelint.vim
@@ -26,9 +26,9 @@ function! SyntaxCheckers_coffee_coffeelint_GetLocList()
         \ 'subchecker': 'coffeelint' })
 
     let errorformat =
-        \ '%f\,%l\,%\d%\+\,%trror\,%m,' .
+        \ '%f\,%l\,%\d%#\,%trror\,%m,' .
         \ '%f\,%l\,%trror\,%m,' .
-        \ '%f\,%l\,%\d%\+\,%tarn\,%m,' .
+        \ '%f\,%l\,%\d%#\,%tarn\,%m,' .
         \ '%f\,%l\,%tarn\,%m'
 
     return SyntasticMake({


### PR DESCRIPTION
I verified that this is working locally.

Thanks @lcd047
https://github.com/scrooloose/syntastic/commit/00dd154122e3aeb8dd67627cf18db69fb801e3fa#commitcomment-3852292
