### PR TITLE
Improve typescript checker

### DIFF
--- a/syntax_checkers/typescript/tsc.vim
+++ b/syntax_checkers/typescript/tsc.vim
@@ -1,6 +1,6 @@
 "============================================================================
 "File:        typescript.vim
-"Description: TypeScript syntax checker. For TypeScript v0.8.0
+"Description: TypeScript syntax checker. For TypeScript v0.8 and v0.9
 "Maintainer:  Bill Casarin <bill@casarin.ca>
 "============================================================================
 
@@ -13,15 +13,18 @@ function! SyntaxCheckers_typescript_tsc_IsAvailable()
     return executable("tsc")
 endfunction
 
-
 function! SyntaxCheckers_typescript_tsc_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'tsc',
-        \ 'post_args': '--out ' . syntastic#util#DevNull(),
+        \ 'post_args': '--module commonjs --out ' . syntastic#util#DevNull(),
         \ 'filetype': 'typescript',
         \ 'subchecker': 'tsc' })
 
-    let errorformat = '%f %#(%l\,%c): %m'
+    let errorformat =
+        \ '%E%f(%l\,%c):\ error\ TS%n: %m,' .
+        \ '%Eerror\ TS%n:\ %m,' .
+        \ '%E%f(%l\,%c): %m,' .
+        \ '%C\	%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
- Make the errorformat correctly capture multi-line messages
- Add errorformat entries for typescript 0.9.x
- In makeprg, specify module system using the --module flag.
  As of typescript 0.9.1, this flag is required. I've chosen
  CommonJs (as opposed to AMD modules) arbitrarily.

I've tested this against both typescript 0.8 and 0.9, and it works for both.
