### PR TITLE
[issue-767] Remove backslash in puppet-lint log format (refs: #767)

### DIFF
--- a/syntax_checkers/puppet/puppetlint.vim
+++ b/syntax_checkers/puppet/puppetlint.vim
@@ -31,7 +31,7 @@ endfunction
 function! SyntaxCheckers_puppet_puppetlint_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'puppet-lint',
-        \ 'post_args': '--log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}"',
+        \ 'post_args': '--log-format "%{KIND} [%{check}] %{message} at %{fullpath}:%{linenumber}"',
         \ 'filetype': 'puppet',
         \ 'subchecker': 'puppetlint' })
 


### PR DESCRIPTION
Hi, this PR solve my problem with issue #767

Puppet-lint format before :

``` bash
$ puppet-lint /tmp/foo.pp --log-format "\%{KIND} [\%{check}] \%{message} at \%{fullpath}:\%{linenumber}"
\ERROR [\autoloader_layout] \foo not in autoload module layout at \/tmp/foo.pp:\1
\WARNING [\documentation] \class not documented at \/tmp/foo.pp:\1
```

 Puppet-lint format after :

``` bash
$ puppet-lint /tmp/foo.pp --log-format "%{KIND} [%{check}] %{message} at %{fullpath}:%{linenumber}"                                                                                
ERROR [autoloader_layout] foo not in autoload module layout at /tmp/foo.pp:1
WARNING [documentation] class not documented at /tmp/foo.pp:1
```

Thanks `let g:syntastic_debug=1` :-)
