### PR TITLE
added g:syntastic_check_on_bufwrite

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -177,6 +177,13 @@ variable to 0. >
     let g:syntastic_check_on_wq=0
 <
 
+                                               *'syntastic_check_on_bufwrite'*
+Default: 1
+Normally syntastic runs syntax checks whenever buffers are written to disk.
+If you want to skip these checks to do them manully set this variable to 0. >
+    let g:syntastic_check_on_bufwrite=0
+<
+
                                                 *'syntastic_aggregate_errors'*
 Default: 0
 When enabled, |:SyntasticCheck| runs all checkers that apply, then aggregates

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -64,6 +64,10 @@ if !exists("g:syntastic_full_redraws")
     let g:syntastic_full_redraws = !( has('gui_running') || has('gui_macvim'))
 endif
 
+if !exists("g:syntastic_check_on_bufwrite")
+    let g:syntastic_check_on_bufwrite = 1
+endif
+
 " TODO: not documented
 if !exists("g:syntastic_reuse_loc_lists")
     " a relevant bug has been fixed in one of the pre-releases of Vim 7.4
@@ -149,7 +153,11 @@ function! s:UpdateErrors(auto_invoked, ...)
         endif
     end
 
-    let loclist = g:SyntasticLoclist.current()
+    if g:syntastic_check_on_bufwrite
+        let loclist = g:SyntasticLoclist.current()
+    else
+        let loclist = g:SyntasticLoclist.New([])
+    endif
 
     let w:syntastic_loclist_set = 0
     if g:syntastic_always_populate_loc_list || g:syntastic_auto_jump


### PR DESCRIPTION
To have the possibility to switch off the auto command to check at
BufWritePost. To me it is kind of enable or disable syntastic but still
have the choice to check manually.
### Update

not stopping the autocmd clearing the loclist is doing what I want
in my rc I use
<code>
:nnoremap <F6> :let g:syntastic_check_on_bufwrite != g:syntastic_check_on_bufwrite <bar> :SyntasticCheck <CR>
</code>
to toggle
