### PR TITLE
Update with explanation of override behaviour

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,7 +106,7 @@ __Q. Recently some of my syntax checker options have stopped working...__
 
 A. The options are still there, they have just been renamed. Recently, almost all syntax checkers were refactored to use the new `syntastic#makeprg#build()` function. This made a lot of the old explicit options redundant - as they are now implied. The new implied options usually have slightly different names to the old options.
 
-e.g. Previously there was `g:syntastic_phpcs_conf`, now you must use `g:syntastic_php_phpcs_args`.
+e.g. Previously there was `g:syntastic_phpcs_conf`, now you must use `g:syntastic_php_phpcs_args`. This completely overrides the arguments of the checker, including any defaults, so you may need to look up the default arguments of the checker and add these in.
 
 See `:help syntastic-checker-options` for more information.
 


### PR DESCRIPTION
Hope I'm clear enough here - I ran into an issue with the phpcs example where it specifies --report=csv by default, adding my options didnt include this default so I had to add my new argument and the default to the option.
