### PR TITLE
Fix a typo (end instead of endif). 

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -147,7 +147,7 @@ function! s:UpdateErrors(auto_invoked, ...)
         else
             call s:CacheErrors()
         endif
-    end
+    endif
 
     let loclist = g:SyntasticLoclist.current()
 


### PR DESCRIPTION
Hi,

This bug prenvented me from using Syntastic on Windows and Vim 7.3.829. Don't know why but in was working on my Mac with Vim 7.4!!

For sure it is an error.

Thx,

Okcompute
