### PR TITLE
Parse multi line warnings correctly 

### DIFF
--- a/syntax_checkers/haskell/hdevtools.vim
+++ b/syntax_checkers/haskell/hdevtools.vim
@@ -28,6 +28,7 @@ function! SyntaxCheckers_haskell_hdevtools_GetLocList()
 
     let errorformat= '\%-Z\ %#,'.
         \ '%W%f:%l:%c:\ Warning:\ %m,'.
+        \ '%W%f:%l:%c:\ Warning:,'.
         \ '%E%f:%l:%c:\ %m,'.
         \ '%E%>%f:%l:%c:,'.
         \ '%+C\ \ %#%m,'.


### PR DESCRIPTION
Fixes multi line warnings in Haskell, which presently come up as errors.
