### PR TITLE
Correct expected return values for checkpatch checker

### DIFF
--- a/syntax_checkers/c/checkpatch.vim
+++ b/syntax_checkers/c/checkpatch.vim
@@ -39,7 +39,7 @@ function! SyntaxCheckers_c_checkpatch_GetLocList()
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'returns': [0],
+        \ 'returns': [0, 1],
         \ 'subtype': 'Style' })
 endfunction
 


### PR DESCRIPTION
checkpatch.pl will return 1 when warnings or errors are found, at least in the
current -next tree.  This commit makes the checkpatch checker work again.
