### PR TITLE
Erlang: support files under test/ folder

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -30,5 +30,7 @@ get_root([], Path) ->
     Path;
 get_root(["src" | Tail], _Path) ->
     lists:reverse(Tail);
+get_root(["test" | Tail], _Path) ->
+    lists:reverse(Tail);
 get_root([_ | Tail], Path) ->
     get_root(Tail, Path).


### PR DESCRIPTION
A common practice of erlang project is to put test case files under `test/` folder. This patch will make syntastic work for files under `test/` as  `src/`.
