### PR TITLE
Adds Literate CoffeeScript support

### DIFF
--- a/syntax_checkers/litcoffee/litcoffee.vim
+++ b/syntax_checkers/litcoffee/litcoffee.vim
@@ -1,0 +1,50 @@
+"============================================================================
+"File:        litcoffee.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Devin Weaver <suki@tritarget.org>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"Notes:       This is a small modification to the coffee syntax checker by
+"             Lincoln Stoll <l@lds.li>
+"
+"============================================================================
+"
+" Note: this script requires CoffeeScript version 1.6.2 or newer.
+"
+if exists("g:loaded_syntastic_litcoffee_litcoffee_checker")
+    finish
+endif
+let g:loaded_syntastic_litcoffee_litcoffee_checker=1
+
+function! SyntaxCheckers_litcoffee_litcoffee_IsAvailable()
+    return executable("coffee") &&
+        \ syntastic#util#versionIsAtLeast(syntastic#util#parseVersion('coffee --version 2>' . syntastic#util#DevNull()), [1,6,2])
+endfunction
+
+function! SyntaxCheckers_litcoffee_litcoffee_GetLocList()
+    let makeprg = syntastic#makeprg#build({
+        \ 'exe': 'coffee',
+        \ 'args': '--literate -cp',
+        \ 'filetype': 'coffee',
+        \ 'subchecker': 'coffee' })
+
+    let errorformat =
+        \ '%E%f:%l:%c: %trror: %m,' .
+        \ 'Syntax%trror: In %f\, %m on line %l,' .
+        \ '%EError: In %f\, Parse error on line %l: %m,' .
+        \ '%EError: In %f\, %m on line %l,' .
+        \ '%W%f(%l): lint warning: %m,' .
+        \ '%W%f(%l): warning: %m,' .
+        \ '%E%f(%l): SyntaxError: %m,' .
+        \ '%-Z%p^,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'litcoffee',
+    \ 'name': 'litcoffee'})


### PR DESCRIPTION
This is pretty much a copy from the CoffeeScript plugin only adding the
`--literate` flag and using a different filetype (litcoffee). You can
associate the litcoffee filetype to files ending in `.litcoffee` and
`.coffee.md` (Many litcoffee plugin provide this).
