### PR TITLE
Support multi-line error messages in the go checker.

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -55,8 +55,8 @@ function! SyntaxCheckers_go_go_GetLocList()
     let errorformat =
         \ '%E%f:%l:%c:%m,' .
         \ '%E%f:%l%m,' .
-        \ '%-G#%.%#,' .
-        \ '%Z%m'
+        \ '%C%\s%\+%m,' .
+        \ '%-G#%.%#'
 
     " The go compiler needs to either be run with an import path as an
     " argument or directly from the package directory. Since figuring out


### PR DESCRIPTION
I'm no errorformat guru, but I think I am doing this right.
Some messages look like:

```
./main.go:315: impossible type assertion:
    gosrc.MemoryCollection does not implement gosrc.Collection (Insert method requires pointer receiver)
```

with one or more indented lines after the main one.
