### PR TITLE
Set noshellslash before performing shellescape()

### DIFF
--- a/autoload/syntastic/util.vim
+++ b/autoload/syntastic/util.vim
@@ -166,7 +166,12 @@ endfunction
 
 " A less noisy shellescape()
 function! syntastic#util#shescape(string)
-    return a:string =~ '\m^[A-Za-z0-9_/.-]\+$' ? a:string : shellescape(a:string)
+    let old_shellslash = &shellslash
+    set noshellslash
+    let string = a:string =~ '\m^[A-Za-z0-9_/.-]\+$' 
+                \ ? a:string : shellescape(a:string)
+    let  &shellslash = old_shellslash
+    return string
 endfunction
 
 " A less noisy shellescape(expand())


### PR DESCRIPTION
On my end this solves Issue #814 (Errors when using python/python syntax checker). After looking in Vim's help it seems `shellescape()` effectively does nothing when `shellslash` is set. 

> shellescape({string} [, {special}])            _shellescape()_
> 
> Escape {string} for use as a shell command argument.
>         On MS-Windows and MS-DOS, when 'shellslash' is not set, it
>         will enclose {string} in double quotes and double all double
>         quotes within {string}.

Since issue #814 and the effects of `shellescape` are windows only, I don't think this would effect other systems. I also don't think people depend on `shellescape()` doing nothing when `shellslash` is set on windows. 

This code basically saves the state of the `shellslash` option before setting `noshellslash`.  Then it performs the `shellescape().` Finally it restores the old state of `shellslash`.
