### PR TITLE
Add foodcritic syntax checker for Chef files

### DIFF
--- a/syntax_checkers/chef/foodcritic.vim
+++ b/syntax_checkers/chef/foodcritic.vim
@@ -22,7 +22,8 @@ endfunction
 function! SyntaxCheckers_chef_foodcritic_GetLocList()
     let makeprg = syntastic#makeprg#build({
           \ 'exe': 'foodcritic',
-          \ 'args': '' })
+          \ 'filetype': 'chef',
+          \ 'subchecker': 'foodcritic' })
 
     " FC023: Prefer conditional attributes: ./recipes/config.rb:49
     let errorformat = 'FC%n: %m: %f:%l'


### PR DESCRIPTION
Requires a ftdetect plugin to set filetype to chef or ruby.chef, e.g. [vim-chef](https://github.com/dougireton/vim-chef)  

Chef is an open-source configuration management tool.
