### PR TITLE
fix Perl @INC management

### DIFF
--- a/syntax_checkers/perl/perl.vim
+++ b/syntax_checkers/perl/perl.vim
@@ -59,7 +59,7 @@ function! SyntaxCheckers_perl_perl_GetLocList()
         let includes = exists('b:syntastic_perl_lib_path') ? b:syntastic_perl_lib_path : g:syntastic_perl_lib_path
     endif
     let shebang = syntastic#util#parseShebang()
-    let extra = join(map(includes, '"-I" . v:val')) .
+    let extra = join(map(copy(includes), '"-I" . v:val')) .
         \ (index(shebang['args'], '-T') >= 0 ? ' -T' : '') .
         \ (index(shebang['args'], '-t') >= 0 ? ' -t' : '')
     let errorformat =  '%f:%l:%m'


### PR DESCRIPTION
Need to 'copy' the 'inlcude' array before operating on it, else successive
calls cause this to pile up.
