### PR TITLE
checkbashisms: shouldn't use -f

### DIFF
--- a/syntax_checkers/sh/checkbashisms.vim
+++ b/syntax_checkers/sh/checkbashisms.vim
@@ -20,7 +20,7 @@ endfunction
 function! SyntaxCheckers_sh_checkbashisms_GetLocList()
     let makeprg = syntastic#makeprg#build({
         \ 'exe': 'checkbashisms',
-        \ 'args': '-fx',
+        \ 'args': '-x',
         \ 'filetype': 'sh',
         \ 'subchecker': 'checkbashisms'})
 


### PR DESCRIPTION
The `-f` flag causes checkbashisms to check files that have `#!/bin/bash` as
if they were `/bin/sh` files.

Without the `-f` it detects the type of file and only runs on actual
`sh` scripts.

An alternative might be to add a `bash` type and not have `checkbashisms` 
there.
