### PR TITLE
html/tidy: placeholder attribute should only be on input elements

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -68,7 +68,7 @@ endfunction
 let s:ignore_errors = [
                 \ "<table> lacks \"summary\" attribute",
                 \ "not approved by W3C",
-                \ "attribute \"placeholder\"",
+                \ "<input> proprietary attribute \"placeholder\"",
                 \ "<meta> proprietary attribute \"charset\"",
                 \ "<meta> lacks \"content\" attribute",
                 \ "inserting \"type\" attribute",


### PR DESCRIPTION
The way the rule is currently set, placeholder on a non-input element would pass, which it should not.

This was introduced in #65 
