### PR TITLE
html/tidy: Allow more HTML5 input types

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -78,7 +78,7 @@ let s:ignore_errors = [
                 \ "inserting missing 'title' element",
                 \ "attribute \"[+",
                 \ "unescaped & or unknown entity",
-                \ "<input> attribute \"type\" has invalid value \"search\""
+                \ "<input> attribute \"type\" has invalid value"
                 \ ]
 
 let s:blocklevel_tags = [


### PR DESCRIPTION
This allows the following:
- search
- number
- range
- date
- etc

Somebody could in theory put type="foo", but all browsers' default input type is "text" and they all ignore unknown types.

This augments #432 
