### PR TITLE
html/tidy: Remove "attribute \"[+" s:ignore_errors rule

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -76,7 +76,6 @@ let s:ignore_errors = [
                 \ "missing <!DOCTYPE> declaration",
                 \ "inserting implicit <body>",
                 \ "inserting missing 'title' element",
-                \ "attribute \"[+",
                 \ "unescaped & or unknown entity",
                 \ "<input> attribute \"type\" has invalid value"
                 \ ]


### PR DESCRIPTION
This seems like this may be specific to a particular environment/framework/toolkit, and if so, it should probably be removed. I suggest leaving this pull request open for a while and see if @Thanatermesis (the origin of this line) or anybody else has a reason for this to stay.

more info: https://github.com/scrooloose/syntastic/commit/a956a814323225f9fce873a14a3d8edc027b7aa5#commitcomment-4537304
