### PR TITLE
html/tidy: Remove hgroup, it is non-conforming

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -86,7 +86,6 @@ let s:blocklevel_tags = [
                 \ "section",
                 \ "article",
                 \ "aside",
-                \ "hgroup",
                 \ "header",
                 \ "footer",
                 \ "nav",


### PR DESCRIPTION
http://www.w3.org/html/wg/drafts/html/master/obsolete.html#hgroup
