### PR TITLE
Bump rubocop version

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -21,7 +21,7 @@ let g:loaded_syntastic_ruby_rubocop_checker=1
 function! SyntaxCheckers_ruby_rubocop_IsAvailable()
     return
         \ executable('rubocop') &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion('rubocop --version'), [0,9,0])
+        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion('rubocop --version'), [0,15,0])
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList()


### PR DESCRIPTION
the version of latest rubocop is 0.15.0. Therefor I bumped it in VimL.

![0025-11-10 8 22 48](https://f.cloud.github.com/assets/1688137/1508436/c23d7a3e-49fa-11e3-8eb2-bacc2a401cd6.png)
