### PR TITLE
oclint does not have -text option any more

### DIFF
--- a/syntax_checkers/c/oclint.vim
+++ b/syntax_checkers/c/oclint.vim
@@ -27,7 +27,6 @@ endif
 
 function! SyntaxCheckers_c_oclint_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '-text',
         \ 'post_args': '-- -c ' . syntastic#c#ReadConfig(g:syntastic_oclint_config_file) })
 
     let errorformat =


### PR DESCRIPTION
Since OCLint 0.7 the -text option is not supported, as a result the checker cannot start any more with current args.
By default, plain text report is used anyway, so i removed the option.
