### PR TITLE
Name specified in ghc-mod.vim is ghc_mod, not ghc-mod.

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -29,7 +29,7 @@ let s:defaultCheckers = {
         \ 'go':          ['go'],
         \ 'haml':        ['haml'],
         \ 'handlebars':  ['handlebars'],
-        \ 'haskell':     ['ghc-mod', 'hdevtools', 'hlint'],
+        \ 'haskell':     ['ghc_mod', 'hdevtools', 'hlint'],
         \ 'haxe':        ['haxe'],
         \ 'hss':         ['hss'],
         \ 'html':        ['tidy'],


### PR DESCRIPTION
After updating syntastic to head, I was unable to get error reporting for haskell files, altough hlint was working properly. Turns out that in _syntax_checkers/haskell/ghc-mod.vim_ the name is specified as `ghc_mod`, while in the registry it was `ghc-mod`.

This should fix it.
Cheers!
