### PR TITLE
Add po syntax checker

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -48,6 +48,7 @@ let s:defaultCheckers = {
         \ 'ocaml':       ['camlp4o'],
         \ 'perl':        ['perl', 'perlcritic'],
         \ 'php':         ['php', 'phpcs', 'phpmd'],
+        \ 'po':          ['msgfmt'],
         \ 'pod':         ['podchecker'],
         \ 'puppet':      ['puppet', 'puppetlint'],
         \ 'python':      ['python', 'flake8', 'pylint'],

--- a/syntax_checkers/po/msgfmt.vim
+++ b/syntax_checkers/po/msgfmt.vim
@@ -1,0 +1,33 @@
+"============================================================================
+"File:        msgfmt.vim
+"Description: Syntax checking plugin for po files of gettext
+"Maintainer:  Ryo Okubo <syucream1031@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_po_msgfmt_checker")
+    finish
+endif
+let g:loaded_syntastic_po_msgfmt_checker=1
+
+function! SyntaxCheckers_po_msgfmt_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': '-c' })
+
+    let errorformat = 
+        \ '%W%f:%l: warning: %m,' .
+        \ '%E%f:%l:%n: %m,' .
+        \ '%E%f:%l: %m,' .
+        \ '%Z%p^,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'po',
+    \ 'name': 'msgfmt'})


### PR DESCRIPTION
Hi,

Add syntax_checher for [po files of gettext](http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html).
I use [msgfmt](http://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html) as syntax checher.
