### PR TITLE
Workaround the issue of filetype lost after auto jump.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -211,6 +211,9 @@ function! s:UpdateErrors(auto_invoked, ...)
         if run_checks && g:syntastic_auto_jump && loclist.hasErrorsOrWarningsToDisplay()
             call syntastic#log#debug(g:SyntasticDebugNotifications, 'loclist: jump')
             silent! lrewind
+            if &ft == '' && exists('did_load_filetypes')
+                silent! filetype detect
+            endif
         endif
     endif
 


### PR DESCRIPTION
I am not sure whether this is a Vim bug or feature, but when `g:syntastic_auto_jump` is set and Syntastic jumps to another buffer by saving the current file, filetype is missing for the new buffer (hence no syntax highlight).  No problem occurs if Syntastic jumps with an explicit `SyntasticCheck` command.  You may want to try the following gist to reproduce the issue:

https://gist.github.com/roktas/7788810

(You may also need the Vim golang plugin: https://github.com/jnwhiteh/vim-golang)
