### PR TITLE
Added --vapidir support to vala

### DIFF
--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -6,7 +6,7 @@
 "             "// modules: " and containing space delimited list of vala
 "             modules, used by the file, so this script can build correct
 "             --pkg arguments.
-"             Add another special camment line into your vala file starting
+"             Add another special comment line into your vala file starting
 "             with "// vapidirs: " followed by a space delimited list of
 "             the vapi directories so this script can build with the correct
 "             --vapidir arguments


### PR DESCRIPTION
Added the ability of the valac syntax checker to inlcude vapi directories in much of the same way as the modules (--pkg) support is implemented. There is both a global variable (g:syntastic_vala_vapidirs) and a magic comment ("// vapidirs: ")
