### PR TITLE
add a copy of the jslint checker as a possible checker for html files

### DIFF
--- a/syntax_checkers/html/jslint.vim
+++ b/syntax_checkers/html/jslint.vim
@@ -2,13 +2,15 @@
 "File:        jslint.vim
 "Description: Javascript syntax checker - using jslint
 "Maintainer:  Martin Grenfell <martin.grenfell at gmail dot com>
+"             adapted by Harry Percival (hjwp2@cantab.net) to lint js in html
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
 "             it and/or modify it under the terms of the Do What The Fuck You
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
-"Tested with jslint 0.1.4.
+"NB - requires jslint <= 0.1.11. versions 0.2+ dropped support for linting
+"                                js inside html
 "============================================================================
 if exists("g:loaded_syntastic_html_jslint_checker")
     finish


### PR DESCRIPTION
ref #805, copy of jslint with s/javascript/html/ as new checker, created by:

```
cp syntax_checkers/javascript/jslint.vim syntax_checkers/html/jslint.vim
sed -i "s/javascript/html/g" !$
```

This would be useful for anyone that wants to check javascript embedded in html.

Can be enabled in .vimrc using:

```
let g:syntastic_html_checkers=['jslint']
```

Appreciate that it's a kludgey solution, since it dupes a lot of code in the two _jslint.vim_s, so won't be offended if you don't accept the PR.

**NB** - requires jslint v <= 0.1.11.  versions 0.2+ dropped support for linting inside html, as far as I can tell
