### PR TITLE
Update readme about overriding exec

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -553,7 +553,7 @@ parameters not specified in the call to makeprgBuild().
 If 'exe' is the same as the checker 'exec' attribute, it may be omitted.
 
 E.g. To override the checker exe above, you could do this: >
-    let g:syntastic_ruby_mri_exe = "another_ruby_checker_exe.rb"
+    let g:syntastic_ruby_mri_exec = "another_ruby_checker_exe.rb"
 <
 To override the args and the tail: >
     let g:syntastic_ruby_mri_args = "--my --args --here"


### PR DESCRIPTION
```
let g:syntastic_css_csslint_exe='~/.vim/node_modules/.bin/csslint' 
```

not working, but

```
g:syntastic_css_csslint_exec='~/.vim/node_modules/.bin/csslint'
```

works fine.
And according to this function https://github.com/scrooloose/syntastic/blob/master/plugin/syntastic/checker.vim#L51
there must be exec instead of exe
