### PR TITLE
javac checker config editing/loading custom classpath command added

### DIFF
--- a/syntax_checkers/java/javac.vim
+++ b/syntax_checkers/java/javac.vim
@@ -68,6 +68,10 @@ if !exists('g:syntastic_java_javac_config_file')
     let g:syntastic_java_javac_config_file = '.syntastic_javac_config'
 endif
 
+if !exists('g:syntastic_java_javac_custom_classpath_command')
+    let g:syntastic_java_javac_custom_classpath_command = ''
+endif
+
 if !exists("g:syntastic_java_javac_maven_pom_ftime")
     let g:syntastic_java_javac_maven_pom_ftime = {}
 endif
@@ -371,6 +375,17 @@ function! SyntaxCheckers_java_javac_GetLocList() dict
             let javac_opts .= ' -d ' . s:MavenOutputDirectory()
         endif
         let javac_classpath = s:AddToClasspath(javac_classpath, s:GetMavenClasspath())
+    endif
+
+    " load custom classpath
+    if g:syntastic_java_javac_custom_classpath_command != ''
+        let lines = system(g:syntastic_java_javac_custom_classpath_command)
+        if has('win32') || has('win32unix') || has('win64')
+            let lines = substitute(lines,"\r\n","\n")
+        endif
+        for l in split(lines, "\n")
+            let javac_classpath = s:AddToClasspath(javac_classpath, l)
+        endfor
     endif
 
     if javac_classpath != ''


### PR DESCRIPTION
This pull request addes following command :SyntasticJavacEditConfig
When g:syntastic_java_javac_config_file_enabled option is on. 
It allows to specify per java project javac checker options in config file enabling much more flexebility in per directory configuration of javac checker options.

Also as noted by https://github.com/scrooloose/syntastic/issues/819 this pull requests addes 
custom classpath command enabling capability to use other tools like ant or gradle or any custom command to specify your own custom classpath. This option can be specified in config file enabling higher level customization of javac checker per project
