### PR TITLE
Do not use print function from the future.

### DIFF
--- a/syntax_checkers/python/compile.py
+++ b/syntax_checkers/python/compile.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 from sys import argv, exit
 
 


### PR DESCRIPTION
Using print function from the future here gives Syntastic errors for "old-style" print usages in legitimate Python2 sources.
