### PR TITLE
Handle mxmlc errors with no line/column numbers

### DIFF
--- a/syntax_checkers/actionscript/mxmlc.vim
+++ b/syntax_checkers/actionscript/mxmlc.vim
@@ -53,6 +53,7 @@ function! SyntaxCheckers_actionscript_mxmlc_GetLocList() dict
     let errorformat =
         \ '%f(%l): col: %c %trror: %m,' .
         \ '%f(%l): col: %c %tarning: %m,' .
+        \ '%f: %trror: %m,' .
         \ '%-G%.%#'
 
     return SyntasticMake({


### PR DESCRIPTION
Just happened across a new error message with mxmlc, which wasn't matched by the current `errorformat` pattern because it didn't contain line and column numbers.  This just adds a new pattern to match such errors.
