### PR TITLE
pylint: include symbolic message name in output

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -23,7 +23,7 @@ endfunction
 
 function! SyntaxCheckers_python_pylint_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': (s:pylint_new ? '--msg-template="{path}:{line}: [{msg_id}] {msg}" -r n' : '-f parseable -r n -i y') })
+        \ 'args': (s:pylint_new ? '--msg-template="{path}:{line}: [{msg_id}/{symbol}] {msg}" -r n' : '-f parseable -r n -i y') })
 
     let errorformat =
         \ '%A%f:%l: %m,' .


### PR DESCRIPTION
pylint is moving away from the numerical message IDs (e.g. W0611)
because they are cumbersome and not descriptive when you come across
them in in-source pylint directives (e.g. # pylint: disable=W0611).

Instead, symbolic names are recommended, and much easier for humans
to use (e.g. # pylint: disable=unused-import).
(See http://docs.pylint.org/faq.html#do-i-have-to-remember-all-these-numbers)

This patch modifies the message output to print both the ID and
symbolic name for the current line in vim.
