### PR TITLE
fix pylint messages when pythonrc specifies format=colorized

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -23,7 +23,7 @@ endfunction
 
 function! SyntaxCheckers_python_pylint_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': (s:pylint_new ? '--msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" -r n' : '-f parseable -r n -i y') })
+        \ 'args': (s:pylint_new ? '-f parseable --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" -r n' : '-f parseable -r n -i y') })
 
     let errorformat =
         \ '%A%f:%l:%c:%t: %m,' .


### PR DESCRIPTION
Currently if a pylintrc specifies format=coloized, you end up with terminal escape codes in the locatiionlist.

Specifying --format=text fixes this, even though it doesn't change the actual format due to --msg-template.

The default pylintrc (from pylint --generate-rcfile) has output-format set to 'text' and details the possible values users can change it to. The obvious intent is to allow people to set it in pylintrc.

```
$ pylint --generate-rcfile | grep format
No config file found, using default configuration
# Set the output format. Available formats are text, parseable, colorized, msvs
output-format=text
I will change my patch to use the default format (text) rather than 'parseable'.
```

Due to your very recent patch, without this fix, format=colorized prevents syntastic+pylint from functioning at all.
