### PR TITLE
Fix Typescript Compiler emitting output

### DIFF
--- a/syntax_checkers/typescript/tsc.vim
+++ b/syntax_checkers/typescript/tsc.vim
@@ -14,8 +14,7 @@ set cpo&vim
 
 function! SyntaxCheckers_typescript_tsc_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '--module commonjs',
-        \ 'post_args': '--out ' . syntastic#util#DevNull() })
+        \ 'args': '--module commonjs --outDir ' . syntastic#util#DevNull() })
 
     let errorformat =
         \ '%E%f %#(%l\,%c): error %m,' .


### PR DESCRIPTION
Typescript compiler 0.9.5 emits output JavaScript with the previous set of arguments, even with --out set to /dev/null. Setting it instead to --outDir /dev/null seems to resolve this issue.
