### PR TITLE
Statusline format can be passed as parameter.

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -116,8 +116,17 @@ Something like this could be more useful: >
     set statusline+=%*
 <
 When syntax errors are detected a flag will be shown. The content of the flag
-is derived from the |syntastic_stl_format| option.
+is derived from the |syntastic_stl_format| option, or you can pass the format
+to SyntasticStatuslineFlag(format):
 
+<
+Something like this could be more useful: >
+    set statusline+=%#warningmsg#
+    set statusline+=%{SyntasticStatuslineFlag("%W{[Warn: %fw(%w)]}")}
+    set statusline+=%#errormsg#
+    set statusline+=%{SyntasticStatuslineFlag("%E{[Err: %fe(%e)]}")}
+    set statusline+=%*
+<
 ------------------------------------------------------------------------------
 2.2. Error signs                                       *syntastic-error-signs*
 

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -400,7 +400,7 @@ endfunction
 "g:syntastic_stl_format
 "
 "return '' if no errors are cached for the buffer
-function! SyntasticStatuslineFlag()
+function! SyntasticStatuslineFlag(...)
     let loclist = g:SyntasticLoclist.current()
     let issues = loclist.getRaw()
     let num_issues = loclist.getLength()
@@ -411,7 +411,11 @@ function! SyntasticStatuslineFlag()
         let num_errors = len(errors)
         let num_warnings = len(warnings)
 
-        let output = g:syntastic_stl_format
+        if a:0 > 0
+            let output = a:1
+        else
+            let output = g:syntastic_stl_format
+        endif
 
         "hide stuff wrapped in %E(...) unless there are errors
         let output = substitute(output, '\m\C%E{\([^}]*\)}', num_errors ? '\1' : '' , 'g')


### PR DESCRIPTION
Change function SyntasticStatuslineFlag to receive the format as
parameter(optional), if no parameter is passed use the g:syntastic_stl_format.
This is useful when you want to use different highlights for erros and
warnings:

``` viml
set statusline+=%#warningmsg#
set statusline+=%{SyntasticStatuslineFlag("%W{[Warn: %fw(%w)]}")}
set statusline+=%#errormsg#
set statusline+=%{SyntasticStatuslineFlag("%E{[Err: %fe(%e)]}")}
set statusline+=%*
```
