### PR TITLE
bug fix for issue962 javac classpath resolve bug

### DIFF
--- a/syntax_checkers/java/javac.vim
+++ b/syntax_checkers/java/javac.vim
@@ -354,7 +354,12 @@ function! SyntaxCheckers_java_javac_GetLocList() dict
     let javac_classpath = ''
 
     " add classpathes to javac_classpath
-    for path in split(g:syntastic_java_javac_classpath, ":")
+    if has('win32') || has('win32unix') || has('win64')
+        let javac_classpath_split = ';'
+    else
+        let javac_classpath_split = ':'
+    endif
+    for path in split(g:syntastic_java_javac_classpath, javac_classpath_split)
         if path != ''
             try
                 let ps = glob(path, 0, 1)


### PR DESCRIPTION
need use ":" as split split(g:syntastic_java_javac_classpath, ":") in new version of syntastic, reference issue: https://github.com/scrooloose/syntastic/issues/962
