### PR TITLE
Fix E706: Variable type mismatch for: v

### DIFF
--- a/autoload/syntastic/util.vim
+++ b/autoload/syntastic/util.vim
@@ -214,7 +214,8 @@ endfunction
 
 function! s:translateFilter(filters)
     let conditions = []
-    for [k, v] in items(a:filters)
+    for k in a:filters
+        let v = a:filters[k]
         if type(v) == type([])
             call extend(conditions, map(copy(v), 's:translateElement(k, v:val)'))
         else


### PR DESCRIPTION
This happens when using different types for filter items.

Error:

>  Error detected while processing function <SNR>149_UpdateErrors..<SNR>149_CacheErrors..232.
>    .syntastic#util#dictFilter..<SNR>150_translateFilter:
>    line    2:
>    E706: Variable type mismatch for: v
