### PR TITLE
Add pattern to match warnings from C compilers when checking Go code.

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -56,7 +56,9 @@ function! SyntaxCheckers_go_go_GetLocList() dict
         let cleanup = 1
     endif
 
+    " The first pattern is for warnings from C compilers.
     let errorformat =
+        \ '%W%f:%l: warning: %m,' .
         \ '%E%f:%l:%c:%m,' .
         \ '%E%f:%l:%m,' .
         \ '%C%\s%\+%m,' .


### PR DESCRIPTION
Otherwise warnings from C code when compiling with packages that use cgo show up as errors.
