### PR TITLE
Enable setting the phpcs standard through .vimrc

### DIFF
--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -21,9 +21,17 @@ let g:loaded_syntastic_php_phpcs_checker = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! GetPhpcsStandardArgs()
+    if exists("g:php_phpcs_checker_standard")
+        return ' --standard=' . g:php_phpcs_checker_standard
+    else
+        return ''
+    endif
+endfunction
+
 function! SyntaxCheckers_php_phpcs_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '--tab-width=' . &tabstop,
+        \ 'args': '--tab-width=' . &tabstop . GetPhpcsStandardArgs(),
         \ 'args_after': '--report=csv' })
 
     let errorformat =


### PR DESCRIPTION
Hi,

First off, thanks for an awesome plugin!

I thought that it would be nice to be able to let vim decide which standard to use and not be dependent on the global `phpcs --config-set default_standard`, thus this PR.

Changes to the standard can be done with

```
let g:php_phpcs_checker_standard="PSR2"
```

I'm looking forward to your comments.
