### PR TITLE
Use explicit function names for preprocess.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -417,7 +417,7 @@ function! SyntasticMake(options) " {{{2
     call syntastic#log#debug(g:SyntasticDebugLoclist, 'checker output:', err_lines)
 
     if has_key(a:options, 'preprocess')
-        let err_lines = call('syntastic#preprocess#' . a:options['preprocess'], [err_lines])
+        let err_lines = call(a:options['preprocess'], [err_lines])
         call syntastic#log#debug(g:SyntasticDebugLoclist, 'preprocess:', err_lines)
     endif
     lgetexpr err_lines

--- a/syntax_checkers/c/cppcheck.vim
+++ b/syntax_checkers/c/cppcheck.vim
@@ -46,7 +46,7 @@ function! SyntaxCheckers_c_cppcheck_GetLocList() dict
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'preprocess': 'cppcheck',
+        \ 'preprocess': 'syntastic#preprocess#cppcheck',
         \ 'returns': [0] })
 
     for e in loclist

--- a/syntax_checkers/html/validator.vim
+++ b/syntax_checkers/html/validator.vim
@@ -72,7 +72,7 @@ function! SyntaxCheckers_html_validator_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'preprocess': 'validator',
+        \ 'preprocess': 'syntastic#preprocess#validator',
         \ 'returns': [0] })
 endfunction
 

--- a/syntax_checkers/java/checkstyle.vim
+++ b/syntax_checkers/java/checkstyle.vim
@@ -46,7 +46,7 @@ function! SyntaxCheckers_java_checkstyle_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'preprocess': 'checkstyle',
+        \ 'preprocess': 'syntastic#preprocess#checkstyle',
         \ 'subtype': 'Style' })
 endfunction
 

--- a/syntax_checkers/javascript/jscs.vim
+++ b/syntax_checkers/javascript/jscs.vim
@@ -24,7 +24,7 @@ function! SyntaxCheckers_javascript_jscs_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
-        \ 'preprocess': 'checkstyle',
+        \ 'preprocess': 'syntastic#preprocess#checkstyle',
         \ 'postprocess': ['sort'],
         \ 'returns': [0, 2] })
 endfunction

--- a/syntax_checkers/perl/perl.vim
+++ b/syntax_checkers/perl/perl.vim
@@ -86,7 +86,7 @@ function! SyntaxCheckers_perl_perl_GetLocList() dict
     let errors = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'preprocess': 'perl',
+        \ 'preprocess': 'syntastic#preprocess#perl',
         \ 'defaults': {'type': 'E'} })
     if !empty(errors)
         return errors
@@ -99,7 +99,7 @@ function! SyntaxCheckers_perl_perl_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'preprocess': 'perl',
+        \ 'preprocess': 'syntastic#preprocess#perl',
         \ 'defaults': {'type': 'W'} })
 endfunction
 

--- a/syntax_checkers/python/pep257.vim
+++ b/syntax_checkers/python/pep257.vim
@@ -25,7 +25,7 @@ function! SyntaxCheckers_python_pep257_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
-        \ 'preprocess': 'killEmpty',
+        \ 'preprocess': 'syntastic#preprocess#killEmpty',
         \ 'postprocess': ['compressWhitespace'] })
 
     " pep257 outputs byte offsets rather than column numbers


### PR DESCRIPTION
The change that prepended all preprocessors with 'syntastic#preprocess#' broke our company-specific checkers, because we use a custom preprocess function. This change allows users with custom checkers to also have custom preprocess steps.
