### PR TITLE
Erlang: search apps/, deps/ and libs/

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -2,7 +2,7 @@
 -export([main/1]).
 
 main([FileName]) ->
-    LibDirs = (["include", "src", "test"] ++
+    LibDirs = (["ebin", "include", "src", "test"] ++
                filelib:wildcard("{apps,deps,lib}/*/{ebin,include}")),
     compile(FileName, LibDirs);
 


### PR DESCRIPTION
Search apps/, deps/ and libs/ for .hrl and .beam files.
Simplify main/1 heads - deconstructing the list cell by cell is not necessary and hardly more readable.
