### PR TITLE
Prioritize jsxhint over jshint

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -40,7 +40,7 @@ let s:defaultCheckers = {
         \ 'hss':         ['hss'],
         \ 'html':        ['tidy'],
         \ 'java':        ['javac'],
-        \ 'javascript':  ['jshint', 'jslint'],
+        \ 'javascript':  ['jsxhint', 'jshint', 'jslint'],
         \ 'json':        ['jsonlint', 'jsonval'],
         \ 'less':        ['lessc'],
         \ 'lex':         ['flex'],


### PR DESCRIPTION
`jsxhint` depends on having `jshint` installed, so if I understand correctly, without this change `jsxhint` will never get selected. If you have `jsxhint` installed it's reasonable to assume you want to use it over `jshint` because it will work fine on normal `.js` file as well as `.jsx` file.

Ideally `jsxhint` would only be available if the file is an actual `jsx` file (i.e., has the `.jsx` extension or the `@jsx` pragma at the start of the file), but I am not sure if Syntastic can make the decision based on file extension or contents.
