### PR TITLE
fix javascript/eslint format

### DIFF
--- a/syntax_checkers/javascript/eslint.vim
+++ b/syntax_checkers/javascript/eslint.vim
@@ -23,6 +23,7 @@ set cpo&vim
 
 function! SyntaxCheckers_javascript_eslint_GetLocList() dict
     let makeprg = self.makeprgBuild({
+        \ 'args_before': '-f compact',
         \ 'args': (g:syntastic_javascript_eslint_conf != '' ? '--config ' . g:syntastic_javascript_eslint_conf : '') })
 
     let errorformat =


### PR DESCRIPTION
eslint recently changed the default formatting of their output (http://eslint.org/blog/2014/01/breaking-change-formatter/), leading syntastic's eslint checks to silently ignore output. Adding this arg restores the previous behavior.
