### PR TITLE
This fixes #80 - make it work on remote files

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -506,7 +506,7 @@ endfunction " }}}2
 function! s:skipFile() " {{{2
     let force_skip = exists('b:syntastic_skip_checks') ? b:syntastic_skip_checks : 0
     let fname = expand('%')
-    return force_skip || (&buftype != '') || !filereadable(fname) || getwinvar(0, '&diff') || s:ignoreFile(fname)
+    return force_skip || (&buftype != '') || getwinvar(0, '&diff') || s:ignoreFile(fname)
 endfunction " }}}2
 
 " Take a list of errors and add default values to them from a:options

--- a/plugin/syntastic/checker.vim
+++ b/plugin/syntastic/checker.vim
@@ -77,15 +77,18 @@ endfunction " }}}2
 
 function! g:SyntasticChecker.makeprgBuild(opts) " {{{2
     let basename = self._filetype . '_' . self._name . '_'
+    let tempfile = tempname()
+    silent execute ": w " . tempfile
 
     let parts = []
     call extend(parts, self._getOpt(a:opts, basename, 'exe', self.getExecEscaped()))
     call extend(parts, self._getOpt(a:opts, basename, 'args', ''))
-    call extend(parts, self._getOpt(a:opts, basename, 'fname', syntastic#util#shexpand('%')))
+    call extend(parts, self._getOpt(a:opts, basename, 'fname', tempfile))
     call extend(parts, self._getOpt(a:opts, basename, 'post_args', ''))
     call extend(parts, self._getOpt(a:opts, basename, 'tail', ''))
 
-    return join(parts)
+
+    return join(parts) . "|perl -pe 's#^" . tempfile . '#' . expand('%') . "#'"
 endfunction " }}}2
 
 function! g:SyntasticChecker.isAvailable() " {{{2


### PR DESCRIPTION
This commit is the first draft of a PoC on how it is possible to have syntastic
work with remote files (so bcvi + netrw + syntastic = win!)

Feedback welcome!

I've never written nor hacked on vim plugins before, so it is ugly, but works.
I'll be more than happy to change the code to fit your requirements.
I think one thing we could easily do is check if the file is readable, then do nothing, and if it isn't, pass it through a regex to see if it's potentially a NetRW, and then use my temporary file (+ rename) trick.
