### PR TITLE
Fix status code lookup array to include a 1.

### DIFF
--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -49,7 +49,7 @@ function! SyntaxCheckers_javascript_jshint_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr('')},
-        \ 'returns': [0, 2] })
+        \ 'returns': [0, 1] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
I believe this fixes: https://github.com/scrooloose/syntastic/issues/1029
