### PR TITLE
Always give absolute paths to syntax checkers 'hdevtools' and 'hlint'

### DIFF
--- a/syntax_checkers/haskell/hdevtools.vim
+++ b/syntax_checkers/haskell/hdevtools.vim
@@ -21,6 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_haskell_hdevtools_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'exe': self.getExecEscaped() . ' check',
+        \ 'fname': syntastic#util#shexpand('%:p'),
         \ 'args': get(g:, 'hdevtools_options', '') })
 
     let errorformat= '\%-Z\ %#,'.

--- a/syntax_checkers/haskell/hlint.vim
+++ b/syntax_checkers/haskell/hlint.vim
@@ -14,7 +14,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_haskell_hlint_GetLocList() dict
-    let makeprg = self.makeprgBuild({})
+    let makeprg = self.makeprgBuild({
+        \ 'fname': syntastic#util#shexpand('%:p')})
 
     let errorformat =
         \ '%E%f:%l:%c: Error: %m,' .


### PR DESCRIPTION
Especially for 'hdevtools' this results into a more robust behaviour,
because 'hdevtools' starts a background process and changing the
current directory doesn't affect the current directory of the background
process.
