### PR TITLE
javac: Allow users to specify Maven options

### DIFF
--- a/syntax_checkers/java/javac.vim
+++ b/syntax_checkers/java/javac.vim
@@ -27,6 +27,10 @@ if !exists("g:syntastic_java_maven_executable")
     let g:syntastic_java_maven_executable = 'mvn'
 endif
 
+if !exists("g:syntastic_java_maven_options")
+    let g:syntastic_java_maven_options = ''
+endif
+
 if !exists("g:syntastic_java_javac_options")
     let g:syntastic_java_javac_options = '-Xlint'
 endif
@@ -226,7 +230,7 @@ function! s:GetMavenProperties()
     let pom = findfile("pom.xml", ".;")
     if s:has_maven && filereadable(pom)
         if !has_key(g:syntastic_java_javac_maven_pom_properties, pom)
-            let mvn_cmd = syntastic#util#shexpand(g:syntastic_java_maven_executable) . ' -f ' . pom
+            let mvn_cmd = syntastic#util#shexpand(g:syntastic_java_maven_executable) . ' -f ' . pom . ' ' . g:syntastic_java_maven_options
             let mvn_is_managed_tag = 1
             let mvn_settings_output = split(system(mvn_cmd . ' help:effective-pom'), "\n")
             let current_path = 'project'
@@ -265,7 +269,7 @@ function! s:GetMavenClasspath()
     let pom = findfile("pom.xml", ".;")
     if s:has_maven && filereadable(pom)
         if !has_key(g:syntastic_java_javac_maven_pom_ftime, pom) || g:syntastic_java_javac_maven_pom_ftime[pom] != getftime(pom)
-            let mvn_cmd = syntastic#util#shexpand(g:syntastic_java_maven_executable) . ' -f ' . pom
+            let mvn_cmd = syntastic#util#shexpand(g:syntastic_java_maven_executable) . ' -f ' . pom . ' ' . g:syntastic_java_maven_options
             let mvn_classpath_output = split(system(mvn_cmd . ' dependency:build-classpath'), "\n")
             let mvn_classpath = ''
             let class_path_next = 0


### PR DESCRIPTION
This patch allows users to specify options to be passed directly to Maven when using the javac syntax checker for Java.

Example usage for setting a Maven profile:

```
let g:syntastic_java_maven_options = '-P myprofile'
```

Any options supported by `mvn` will be supported here, too.
