### PR TITLE
Adding recess syntax checker for CSS files

### DIFF
--- a/syntax_checkers/css/recess.vim
+++ b/syntax_checkers/css/recess.vim
@@ -10,7 +10,7 @@
 "============================================================================
 "
 " Specify additional options to recess with this option. e.g. to disable
-" warnings:
+" errors when applying styles to ids :
 "
 "   let g:syntastic_recess_options = '--noIDs false'
 
@@ -26,28 +26,10 @@ endif
 function! SyntaxCheckers_css_recess_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args': '--format=compact --stripColors ' . g:syntastic_recess_options })
 
-     let errorformat = ''
-
-
-    " Multiline parse error :
-    " -----
-    " Parser error in buttons.css
-    " 
-    "       34.   background: #333333;
-    "       35.   unknown-property: foo();
-    "       36.   color: red;
-    " -----
-    let errorformat .= '%E%m in %f,'
-    let errorformat .= '%Z %#%l.%.%#,'
-
-    " Single line error messages
-    " -----
-    " forms.css:9:No need to specify units when a value is 0
-    " -----
-    let errorformat .= '%f:%l:%m,'
-    
-    " We won't keep anything else
-    let errorformat .= '%-G%.%#'
+    let errorformat = '%E%m in %f,' .
+        \ '%Z %#%l.%.%#,' .
+        \ '%f:%l:%m,' .
+        \ '%-G%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
This is a new CSS syntax checker, using [recess](http://twitter.github.io/recess/). I based the file on the `csslint.vim` one and mostly updated the `errorformat` and default options.

As this is my very first PR, tell me if I overlooked anything. Thanks.
