### PR TITLE
Add global flag for args supplied by user / vimrc

### DIFF
--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -18,17 +18,21 @@ if exists("g:loaded_syntastic_php_phpcs_checker")
 endif
 let g:loaded_syntastic_php_phpcs_checker = 1
 
+if !exists("g:syntastic_php_phpcs_conf")
+    let g:syntastic_php_phpcs_conf = ""
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_php_phpcs_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '--tab-width=' . &tabstop,
+        \ 'args': '--tab-width=' . &tabstop . ' ' . g:syntastic_php_phpcs_conf,
         \ 'args_after': '--report=csv' })
 
     let errorformat =
-        \ '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity%.%#,'.
-        \ '"%f"\,%l\,%v\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
+        \ '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity,'.
+        \ '"%f"\,%l\,%v\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
Added a global flag so the user can override the default settings.

It's not polished, but it works. I use it with CakePHP like this:

```
let g:syntastic_php_phpcs_conf = "--standard=CakePHP --tab-width="
```
