### PR TITLE
adjust R checkers to use absolute file paths

### DIFF
--- a/syntax_checkers/r/lint.vim
+++ b/syntax_checkers/r/lint.vim
@@ -41,7 +41,7 @@ endfunction
 function! SyntaxCheckers_r_lint_GetLocList() dict
     let makeprg = self.getExecEscaped() . ' --slave --restore --no-save' .
         \ ' -e ' . syntastic#util#shescape('library(lint); try(lint(commandArgs(TRUE), ' . g:syntastic_r_lint_styles . '))') .
-        \ ' --args ' . syntastic#util#shexpand('%')
+        \ ' --args ' . syntastic#util#shexpand('%:p')
 
     let errorformat =
         \ '%t:%f:%l:%v: %m,' .

--- a/syntax_checkers/r/svtools.vim
+++ b/syntax_checkers/r/svtools.vim
@@ -54,7 +54,7 @@ function! SyntaxCheckers_r_svtools_GetLocList() dict
     let makeprg = self.getExecEscaped() . ' --slave --restore --no-save' .
         \ ' -e ' . syntastic#util#shescape('library(svTools); ' .
         \       'try(lint(commandArgs(TRUE), filename = commandArgs(TRUE), type = "flat", sep = ":"))') .
-        \ ' --args ' . syntastic#util#shexpand('%')
+        \ ' --args ' . syntastic#util#shexpand('%:p')
 
     let errorformat =
         \ '%trror:%f:%\s%#%l:%\s%#%v:%m,' .


### PR DESCRIPTION
Hi,

the R syntax checkers obviously do have a problem with relative path names (at least on windows I suppose). I personally do not use R but I received the report via twitter: https://twitter.com/BOACK_/status/474123482112872449

@lcd047: since you wrote the checker - any objections? :-)

Cheers,
Gregor
