### PR TITLE
ruby-lint: removed analyze sub-command

### DIFF
--- a/syntax_checkers/ruby/rubylint.vim
+++ b/syntax_checkers/ruby/rubylint.vim
@@ -20,7 +20,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_ruby_rubylint_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args': 'analyze --presenter=syntastic' })
+    let makeprg = self.makeprgBuild({ 'args': '--presenter=syntastic' })
 
     let errorformat = '%f:%t:%l:%c: %m'
 


### PR DESCRIPTION
Starting with ruby-lint 2.0 the "analyze" sub command no longer exists.

Side note: there should probably be a version guard to require 2.0 or newer but I have no idea how to add those :/
