### PR TITLE
update makeprgBuild documentation: filename -> fname

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -598,7 +598,7 @@ Checkers that use 'makeprgBuild()' construct a 'makeprg' like this: >
                 \ 'tail': '> /tmp/output' })
 <
 The result is a 'makeprg' of the form: >
-    <exe> <args> <filename> <post_args> <tail>
+    <exe> <args> <fname> <post_args> <tail>
 <
                                         *'syntastic_<filetype>_<checker>_exe'*
 All arguments above are optional, and can be overridden by setting global


### PR DESCRIPTION
The rationale for this change is that `makeprgBuild` uses `fname` as the
parameter name to retrieve the file path. Therefore, the documentation
has been changed to match the code.
