### PR TITLE
Use --parse-only by default with rustc.

### DIFF
--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -19,7 +19,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args': '--no-trans' })
+    let makeprg = self.makeprgBuild({ 'args': '--parse-only' })
 
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .


### PR DESCRIPTION
This reverts a previous change to use --no-trans by default when
calling the Rust compiler. --no-trans is a more useful mode, but
doesn't quite fit with Syntastic's model. Instead, --parse-only
will check that the syntax of a Rust file is valid and it will
always work. --parse-only is a more useful _default_ mode.
