### PR TITLE
Add basic support for handling usage of the env binary in shebangs

### DIFF
--- a/autoload/syntastic/util.vim
+++ b/autoload/syntastic/util.vim
@@ -40,7 +40,12 @@ function! syntastic#util#parseShebang() " {{{2
 
         if line =~ '^#!'
             let exe = matchstr(line, '\m^#!\s*\zs[^ \t]*')
-            let args = split(matchstr(line, '\m^#!\s*[^ \t]*\zs.*'))
+            if exe !~ '/env$'
+                let args = split(matchstr(line, '\m^#!\s*[^ \t]*\zs.*'))
+            else
+                let exe = matchstr(line, '\m^#!\s*\zs[^ \t]*\s*[^ \t]*')
+                let args = split(matchstr(line, '\m^#!\s*[^ \t]*\s*[^ \t]*\zs.*'))
+            endif
             return { 'exe': exe, 'args': args }
         endif
     endfor


### PR DESCRIPTION
Make the parseShebang function check for the usage of the env binary and
if found include the immediately proceeding argument as part of the exe
variable we return. This ensures we use the correct shell when parsing
files which use the env binary for improved portability. We don't check
for arguments to env at present, but they're rarely used, and this seems
to still be an improvement over the current situation.
