### PR TITLE
Fixes duplicate syntax checker for arduino files

### DIFF
--- a/syntax_checkers/arduino/avrgcc.vim
+++ b/syntax_checkers/arduino/avrgcc.vim
@@ -18,7 +18,7 @@ let g:loaded_syntastic_arduino_avrgcc_checker = 1
 runtime! syntax_checkers/c/*.vim
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-    \ 'filetype': 'c',
+    \ 'filetype': 'arduino',
     \ 'name': 'avrgcc',
     \ 'exec': 'avr-gcc',
     \ 'redirect': 'c/avrgcc'})


### PR DESCRIPTION
I'm getting the "duplicate syntax check" when opening arduino files

E605: Exception not caught: Syntastic: Duplicate syntax checker name: c/avrgcc

So I have changed the filetype for arduino /avrgcc and it's working right now :metal:
