### PR TITLE
Fix not to create NUL file by tsc in Windows

### DIFF
--- a/syntax_checkers/typescript/tsc.vim
+++ b/syntax_checkers/typescript/tsc.vim
@@ -13,9 +13,15 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_typescript_tsc_GetLocList() dict
+    if syntastic#util#isRunningWindows()
+        let out = tempname()
+    elseif
+        let out = syntastic#util#DevNull()
+    endif
+
     let makeprg = self.makeprgBuild({
         \ 'args': '--module commonjs',
-        \ 'args_after': '--out ' . syntastic#util#DevNull() })
+        \ 'args_after': '--out ' . out })
 
     let errorformat =
         \ '%E%f %#(%l\,%c): error %m,' .
@@ -27,6 +33,10 @@ function! SyntaxCheckers_typescript_tsc_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr("")} })
+
+    if syntastic#util#isRunningWindows()
+        call delete(out)
+    endif
 
     call self.setWantSort(1)
 


### PR DESCRIPTION
In windows, `tsc`, the TypeScript compiler for Node.js, creates the file passed
by `--out` argument, even if the file name is `NUL`.
This will pass a temporary file name to `--out` argument, and remove the file
after compilation, only in Windows.
