### PR TITLE
Modified phpmd to be able to specify a custom ruleset

### DIFF
--- a/syntax_checkers/php/phpmd.vim
+++ b/syntax_checkers/php/phpmd.vim
@@ -18,6 +18,11 @@ if exists("g:loaded_syntastic_php_phpmd_checker")
 endif
 let g:loaded_syntastic_php_phpmd_checker = 1
 
+" Rule set built-in or XML file for mess detector, comma separated
+if !exists("g:syntastic_php_phpmd_ruleset")
+    let g:syntastic_php_phpmd_ruleset='codesize,design,unusedcode,naming'
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -60,7 +65,7 @@ endfunction
 function! SyntaxCheckers_php_phpmd_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'post_args_before': 'text',
-        \ 'post_args': 'codesize,design,unusedcode,naming' })
+        \ 'post_args': g:syntastic_php_phpmd_ruleset })
 
     let errorformat = '%E%f:%l%\s%#%m'
 


### PR DESCRIPTION
I've run into an issue whereby I had to specify a custom ruleset but syntastic doesn't allow me to do that at the moment, the phpmd rulesets are hardcoded.

I've made a new option called syntastic_php_phpmd_ruleset which defaults to the current values if its not specified but if you pass it a valid ruleset.xml it will use that instead
