### PR TITLE
Add new clang-tidy and clang-check checkers

### DIFF
--- a/syntax_checkers/c/clang_check.vim
+++ b/syntax_checkers/c/clang_check.vim
@@ -1,0 +1,35 @@
+if exists("g:loaded_syntastic_c_clang_check_checker")
+  finish
+endif
+let g:loaded_syntastic_c_clang_check_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_clang_check_IsAvailable() dict
+  return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_c_clang_check_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f:%l:%c: %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat})
+
+    call self.setWantSort(1)
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'clang_check',
+    \ 'exec': 'clang-check'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/syntax_checkers/c/clang_tidy.vim
+++ b/syntax_checkers/c/clang_tidy.vim
@@ -1,0 +1,35 @@
+if exists("g:loaded_syntastic_c_clang_tidy_checker")
+  finish
+endif
+let g:loaded_syntastic_c_clang_tidy_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_clang_tidy_IsAvailable() dict
+  return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_c_clang_tidy_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f:%l:%c: %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat})
+
+    call self.setWantSort(1)
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'clang_tidy',
+    \ 'exec': 'clang-tidy'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/syntax_checkers/cpp/clang_check.vim
+++ b/syntax_checkers/cpp/clang_check.vim
@@ -1,0 +1,14 @@
+if exists("g:loaded_syntastic_cpp_clang_check_checker")
+  finish
+endif
+let g:loaded_syntastic_cpp_clang_check_checker = 1
+
+runtime! syntax_checkers/c/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'cpp',
+    \ 'name': 'clang_check',
+    \ 'exec': 'clang-check',
+    \ 'redirect': 'c/clang_check'})
+
+" vim: set et sts=4 sw=4:

--- a/syntax_checkers/cpp/clang_tidy.vim
+++ b/syntax_checkers/cpp/clang_tidy.vim
@@ -1,0 +1,14 @@
+if exists("g:loaded_syntastic_cpp_clang_tidy_checker")
+  finish
+endif
+let g:loaded_syntastic_cpp_clang_tidy_checker = 1
+
+runtime! syntax_checkers/c/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'cpp',
+    \ 'name': 'clang_tidy',
+    \ 'exec': 'clang-tidy',
+    \ 'redirect': 'c/clang_tidy'})
+
+" vim: set et sts=4 sw=4:


### PR DESCRIPTION
These checkers use an existing compilation database so that the actual
flags used in the compile are used in the check.
