### PR TITLE
Fix bad variable initialization

### DIFF
--- a/syntax_checkers/ocaml/camlp4o.vim
+++ b/syntax_checkers/ocaml/camlp4o.vim
@@ -71,7 +71,7 @@ if !exists('g:syntastic_ocaml_use_ocamlc') || !executable('ocamlc')
 endif
 
 if !exists('g:syntastic_ocaml_use_janestreet_core')
-    let g:syntastic_ocaml_use_ocamlc = 0
+    let g:syntastic_ocaml_use_janestreet_core = 0
 endif
 
 if !exists('g:syntastic_ocaml_use_ocamlbuild') || !executable("ocamlbuild")


### PR DESCRIPTION
Previously, non-core users could not use ocamlc as their syntax checker because this check would reset the wrong variable. 
Setting g:syntastic_ocaml_use_ocamlc without core now works as intended.
