### PR TITLE
Do not `expand()` shell vars

### DIFF
--- a/syntax_checkers/sh/sh.vim
+++ b/syntax_checkers/sh/sh.vim
@@ -57,7 +57,7 @@ function! s:GetShell()
         endif
         " try to use env variable in case no shebang could be found
         if b:shell == ''
-            let b:shell = fnamemodify(expand('$SHELL'), ':t')
+            let b:shell = fnamemodify($SHELL, ':t')
         endif
     endif
     return b:shell


### PR DESCRIPTION
This is especially important when testing/using variables that do not
exist, because then a new shell is spawned by Vim.
But since they should beavailable already in Vim from the (shell) env
there is no point in doing so.

See also: http://www.reddit.com/r/vim/comments/2el2zo

It is not really relevant here, because `$SHELL` will typically exists, but a good habit anyway.
