### PR TITLE
Add a fcshctl_mxmlc syntax checker for actionscript

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -6,7 +6,7 @@ let g:loaded_syntastic_registry = 1
 " Initialisation {{{1
 
 let s:defaultCheckers = {
-        \ 'actionscript':['mxmlc'],
+        \ 'actionscript':['fcshctl_mxmlc', 'mxmlc'],
         \ 'ada':         ['gcc'],
         \ 'applescript': ['osacompile'],
         \ 'arduino':     ['avrgcc'],

--- a/syntax_checkers/actionscript/fcshctl_mxmlc.vim
+++ b/syntax_checkers/actionscript/fcshctl_mxmlc.vim
@@ -1,0 +1,72 @@
+"==============================================================================
+"File:          fcshctl_mxmlc.vim
+"Description:   ActionScript syntax checker - using fcshctl and mxmlc
+"Maintainer:    Vincent Cogne <vincent.cogne@gmail.com>
+"License:       This program is free software. It comes without any warranty,
+"               to the extent permitted by applicable law. You can redistribute
+"               it and/or modify it under the terms of the Do What The Fuck You
+"               Want To Public License, Version 2, as published by Sam Hocevar.
+"               See http://sam.zoy.org/wtfpl/COPYING for more details.
+" Installation: Install fcshctl http://hasseg.org/blog/post/194/fcshctl-the-flex-compiler-shell-controller/ 
+"               as well as this script: https://github.com/lettertwo/as3CompilerErrors-tmplugin/blob/master/AS3Errors/resources/scripts/fcshctl-mxmlc
+"==============================================================================
+
+
+if exists('g:loaded_syntastic_actionscript_fcshctl_mxmlc_checker')
+    finish
+endif
+let g:loaded_syntastic_actionscript_fcshctl_mxmlc_checker = 1
+
+if !exists('g:syntastic_actionscript_fcshctl_mxmlc_conf')
+    let g:syntastic_actionscript_fcshctl_mxmlc_conf = ''
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_actionscript_fcshctl_mxmlc_GetHighlightRegex(item)
+    let term = ''
+
+    if match(a:item['text'], '\mvariable ''') > -1
+        let term = matchstr(a:item['text'], '\m''\zs[^'']\+\ze''')
+
+    elseif match(a:item['text'], 'expected a definition keyword') > -1
+        let term = matchstr(a:item['text'], '\mnot \zs[^.]\+\ze\.')
+
+    elseif match(a:item['text'], '\mundefined \%(property\|method\)') > -1
+        let term = matchstr(a:item['text'], '\mundefined \%(property\|method\) \zs[^. ]\+\ze')
+
+    elseif match(a:item['text'], 'could not be found') > -1
+        let term = matchstr(a:item['text'], '\m \zs\S\+\ze could not be found')
+
+    elseif match(a:item['text'], 'Type was not found') > -1
+        let term = matchstr(a:item['text'], '\m: \zs[^.]\+\zs\.')
+
+    endif
+
+    return term != '' ? '\V\<' . escape(term, '\') . '\>' : ''
+endfunction
+
+function! SyntaxCheckers_actionscript_fcshctl_mxmlc_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'args_before': (g:syntastic_actionscript_fcshctl_mxmlc_conf != '' ?
+        \   ' -load-config+=' . g:syntastic_actionscript_fcshctl_mxmlc_conf : ''),
+        \ 'args_after': '-output=' . syntastic#util#DevNull() })
+
+    let errorformat =
+        \ '%f(%l): col: %c %trror: %m,' .
+        \ '%f(%l): col: %c %tarning: %m,' .
+        \ '%f: %trror: %m,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'actionscript',
+    \ 'name': 'fcshctl_mxmlc'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
Fcshctl allow mxmlc to run way faster (http://hasseg.org/blog/post/194/fcshctl-the-flex-compiler-shell-controller/). This syntax checker takes advantage of it. In order to make it work, one must install fcshctl and install, in the same folder, this script: https://github.com/lettertwo/as3CompilerErrors-tmplugin/blob/master/AS3Errors/resources/scripts/fcshctl-mxmlc This script is needed because syntastic doesn't allow spaces in the checker name, therefore "fcshctl mxmlc" don't work but "fcshctl_mxmlc" does.
