### PR TITLE
Bug fix: highlighting on python frosted checker

### DIFF
--- a/syntax_checkers/python/frosted.vim
+++ b/syntax_checkers/python/frosted.vim
@@ -42,7 +42,7 @@ function! SyntaxCheckers_python_frosted_GetLocList() dict
         if len(parts) >= 4
             let e["type"] = parts[1][0]
             let e["text"] = parts[3] . ' [' . parts[1] . ']'
-            let e["hl"] = '\V' . escape(parts[2], '\')
+            let e["hl"] = '\V\<' . escape(parts[2], '\') . '\>'
         elseif e["text"] =~? '\v^I\d+:'
             let e["valid"] = 0
         else


### PR DESCRIPTION
Example file:

``` python
class Axle(object): pass

def f():
  x = Axle()
  return 3

if __name__ == '__main__': f()
```

The error: local variable 'x' is assigned to but never used [E307]

The `x` in `Axle` was highlighted.
