### PR TITLE
Erlang: correctly handle additional LibDirs

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -32,7 +32,7 @@ main([FileName, "-rebar", Path, LibDirs]) ->
     %io:format("~p~n", [LibDirs1]),
     compile(FileName, LibDirs1);
 
-main([FileName, LibDirs]) ->
+main([FileName | LibDirs]) ->
     compile(FileName, LibDirs).
 
 compile(FileName, LibDirs) ->


### PR DESCRIPTION
The compile function expects a list of paths in the LibDirs parameter,
however when calling erlang_check_file.erl with an additional path (for
example when using the "g:syntastic_erlc_include_path" option), a
string would be passed instead. Because strings in Erlang are lists,
each character of the string would have been interpreted as a lib path.
