### PR TITLE
scss-lint: do not assign/use subtype=Style for errors

### DIFF
--- a/syntax_checkers/scss/scss_lint.vim
+++ b/syntax_checkers/scss/scss_lint.vim
@@ -27,11 +27,18 @@ endfunction
 function! SyntaxCheckers_scss_scss_lint_GetLocList() dict
     let makeprg = self.makeprgBuild({})
     let errorformat = '%f:%l [%t] %m'
-    return SyntasticMake({
+    let loclist =  SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'subtype': 'Style',
         \ 'returns': [0, 1, 2, 65, 66] })
+
+    for e in loclist
+        if e['type'] != 'E'
+            let e['subtype'] = 'Style'
+        endif
+    endfor
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
This is in line with the other sass/scss checkers.

Ref / main fix for: https://github.com/scrooloose/syntastic/issues/1188
