### PR TITLE
Add support for bashate.

### DIFF
--- a/syntax_checkers/sh/bashate.vim
+++ b/syntax_checkers/sh/bashate.vim
@@ -5,6 +5,12 @@
 "             Can be downloaded from:
 "             https://pypi.python.org/pypi/bashate or
 "             https://github.com/openstack-dev/bashate
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
 "============================================================================
 
 if exists("g:loaded_syntastic_sh_bashate_checker")


### PR DESCRIPTION
Bashate is a pep8 equivalent for bash scripts.
