### PR TITLE
Make syntastic use its own cucumber profile

### DIFF
--- a/syntax_checkers/cucumber/cucumber.vim
+++ b/syntax_checkers/cucumber/cucumber.vim
@@ -19,7 +19,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_cucumber_cucumber_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--dry-run --quiet --strict --format pretty' })
+    let makeprg = self.makeprgBuild({ 'args_after': '--dry-run --quiet --strict --format pretty --profile syntastic' })
 
     let errorformat =
         \ '%f:%l:%c:%m,' .


### PR DESCRIPTION
In a Rails app, when you generate the default cucumber configuration
file specified at config/cucumber.yml and you need to have your profiles
all require the features folder explicitly, your cucumber.yml will end
up looking like this:

``` ruby
<%
rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --tags ~@wip"
%>
default: --require features <%= std_opts %>
wip:     --require features --tags @wip:3 --wip
rerun:   --require features <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
```

The explicit require of the features folder is because of the hierarchy
in our features folder is fairily granular/organized and we're using
site prism page objects as well.

The problem is that syntastic won't properly alert you of missing step
definitions, it just doesn't output anything in the gutter if you have
`--require features` on the default profile, which is the profile that
syntastic uses currently.

However, without the --require features (or just -r features) flag in
the cucumber.yml file, syntastic was reporting ALL step definitions as
undefined (again, because of our folder structure I think).

To re-iterate with the --require features flag syntastic just doesn't
output anything.

Currently syntastic uses the default cucumber profile, so the only way
I was able to get syntastic to work properly was to require the
step_definitions folder for the default profile in the cucumber.yml file
explicitly like this:

``` ruby
default: --require features/step_definitions <%= std_opts %>
```

This worked at the syntastic level. However, cucumber wouldn't properly
run, it didn't have everything required that it needed.

So I ended up needing to add a specific syntastic profile (this commit)
And then the resulting config/cucumber.yml file looks like this:

``` ruby
<%
rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --tags ~@wip"
%>
syntastic: --require features/step_definitions <%= std_opts %>
default:   --require features                  <%= std_opts %>
guard:     --require features                  --format Fivemat --strict --tags ~@wip --tags ~@slow
wip:       --require features                  --tags @wip:3 --wip
rerun:     --require features                  <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
```

With syntastic on it's own profile with the step_definitions folder
explicitly required, and the default profile and others using the higher
level features folder for their require, everyone is happy. Cucumber
runs perfectly, and sytastic properly reports all missing step
definitions, and ONLY the missing one.

If there is another way to fix this I'm all ears. The only down side of
this is that unless users add the syntastic profile to
config/cucumber.yml, then syntastic won't output anything. But I'm not
sure that is such a bad thing. You don't get any erronous warnings by
defualt of ALL step definitions being undefined, and if you add the
proper profile to your config/cucumber.yml it'll work.

One other benefit is that requiring down to the specific
step_definitions folder for the syntastic profile is that the --dry-run
executes MUCH more quickly. It used to take 2-3 seconds before syntastic
would output any gutter info in a .feature file, now isn't under one
second and it actually works!
