### PR TITLE
Categorize scss-lint syntax errors as Syntax subtype

### DIFF
--- a/syntax_checkers/scss/scss_lint.vim
+++ b/syntax_checkers/scss/scss_lint.vim
@@ -31,11 +31,21 @@ endfunction
 function! SyntaxCheckers_scss_scss_lint_GetLocList() dict
     let makeprg = self.makeprgBuild({})
     let errorformat = '%f:%l [%t] %m'
-    return SyntasticMake({
+
+    let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
         \ 'returns': [0, 1, 2, 65, 66] })
+
+    " Categorize syntax errors with syntax subtype instead of style
+    for e in loclist
+        if e['text'] =~ '^Syntax Error:'
+          let e['subtype'] = 'Syntax'
+        endif
+    endfor
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
Previously, all errors/warnings reported by `scss-lint` were considered
style errors in Syntastic.

Commit https://github.com/causes/scss-lint/commit/25ec426999230d74399fb133cdb483ca5ac3eb68
(which will be released in version 0.30.0 of `scss-lint`) includes the
prefix "Syntax Error" at the beginning of all syntax errors, so it can
be easily detected whether an error is a style or syntax error.

There's no need to add a version check as we're fine with older versions
of `scss-lint` continuing to report syntax errors as style errors.

Closes #1189.
