### PR TITLE
make golint report warnings instead of errors

### DIFF
--- a/syntax_checkers/go/golint.vim
+++ b/syntax_checkers/go/golint.vim
@@ -28,6 +28,7 @@ function! SyntaxCheckers_go_golint_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'defaults': {'type': 'w'},
         \ 'subtype': 'Style' })
 endfunction
 


### PR DESCRIPTION
Just like govet, it should report warnings, not errors.
