### PR TITLE
Add 1 to JSCS exit codes

### DIFF
--- a/syntax_checkers/javascript/jscs.vim
+++ b/syntax_checkers/javascript/jscs.vim
@@ -31,7 +31,7 @@ function! SyntaxCheckers_javascript_jscs_GetLocList() dict
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
         \ 'preprocess': 'checkstyle',
-        \ 'returns': [0, 2] })
+        \ 'returns': [0, 1, 2] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
In 0bb8c7e, `2` was added to the list of exit codes that JSCS
is expected to return, in response to #1006. However, it seems that JSCS
now also exits with code 1. In practice, this means that whenever you
save a file with a JavaScript syntax error, you see the following
message:

> syntastic: error: checker javascript/jscs returned abnormal status 1
> Press ENTER or type command to continue

After a quick look at the JSCS code, it appears that it is expected to
exit with codes 0, 1, or 2, so I am adding 1 to the list in this plugin.
