### PR TITLE
Flow checker javascript

### DIFF
--- a/syntax_checkers/javascript/flow.vim
+++ b/syntax_checkers/javascript/flow.vim
@@ -33,15 +33,12 @@ function! SyntaxCheckers_javascript_flow_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'args': '' })
 
-    " BLANK LINE
-    let errorformat = '%E'
-    " ^FILEPATH:LINE:COL:UNKNOWN:ERROR_START
-    let errorformat .= ',%C%f:%l:%v\,%c: %m'
-    " ^IGNORE ERROR_CONTINUE
-    let errorformat .= ',%C%\w%\\+%m'
-    " ^  OTHER_FILEPATH:LINE:COL:UNKNOWN: ERROR_END
-    let errorformat .= ',%Z%\s%m'
-    let errorformat .= ',%Z%m'
+    let errorformat =
+                \ '%E,' .
+                \ '%C%f:%l:%v\,%c: %m,' .
+                \ '%C%\w%\\+%m,' .
+                \ '%Z%\s%m,' .
+                \ '%Z%m'
 
     return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endfunction


### PR DESCRIPTION
Enable:

```
let g:syntastic_javascript_checkers=['flow']
```

Usage:
- Installing flow: `npm install -g flow-bin`
- Setup project for flow: `flow init` at project root
- Open any JavaScript file in project, save

This is my first attempt at adding a syntax checker, and honestly getting the errorformat string even close to working was quite challenging for me. I am not entirely happy with the output, but flow's output combined with my inexperience with errorformat makes it difficult for me to see how to improve it.

It does work however, I'm using it.
