### PR TITLE
JSCS checker: change to the directory of the file being linted

### DIFF
--- a/syntax_checkers/javascript/jscs.vim
+++ b/syntax_checkers/javascript/jscs.vim
@@ -28,6 +28,7 @@ function! SyntaxCheckers_javascript_jscs_GetLocList() dict
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
+        \ 'cwd': expand('%:p:h'),
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
         \ 'preprocess': 'checkstyle',


### PR DESCRIPTION
JSLint, JSCS, and ESLint all support detecting config files. JSLint and ESLint use an exact config if specified, otherwise they look for one in the folder of the file, traversing upwards if none is found.

But JSCS currently looks in the current working folder, meaning that if someone opens files in several projects with different JSCS settings, the correct JSCS config will only be honored if they manually change the current working directory first.

The JSCS maintainers are working on making the config detection closer to JSLint/ESLint's (https://github.com/jscs-dev/node-jscs/issues/559), but in the meantime, this patch can normalize the behavior of the JSCS checker to better match the other common JS checkers.