### PR TITLE
Make tab-width and columnchar depend on expandtab

### DIFF
--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -15,12 +15,20 @@ if exists("g:loaded_syntastic_php_phpcs_checker")
 endif
 let g:loaded_syntastic_php_phpcs_checker = 1
 
+if !exists('g:syntastic_php_phpcs_tab_width')
+    let g:syntastic_php_phpcs_tab_width = 4
+endif
+
+if !exists('g:syntastic_php_phpcs_column_specifier')
+    let g:syntastic_php_phpcs_column_specifier = '%c'
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_php_phpcs_GetLocList() dict
-    if &expandtab
-        let args = '--tab-width=' . &tabstop
+    if g:syntastic_php_phpcs_tab_width
+        let args = '--tab-width=' . g:syntastic_php_phpcs_tab_width
     else
         let args = ''
     endif
@@ -31,7 +39,7 @@ function! SyntaxCheckers_php_phpcs_GetLocList() dict
 
     let errorformat =
         \ '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity%.%#,'.
-        \ '"%f"\,%l\,%c\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
+        \ '"%f"\,%l\,' . g:syntastic_php_phpcs_column_specifier . '\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -19,13 +19,21 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_php_phpcs_GetLocList() dict
+    if &expandtab
+        let args = '--tab-width=' . &tabstop
+        let columnchar = '%v'
+    else
+        let args = ''
+        let columnchar = '%c'
+    endif
+
     let makeprg = self.makeprgBuild({
-        \ 'args': '--tab-width=' . &tabstop,
-        \ 'args_after': '--report=csv' })
+        \ 'args_after': '--report=csv',
+        \ 'args': args })
 
     let errorformat =
         \ '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity%.%#,'.
-        \ '"%f"\,%l\,%v\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
+        \ '"%f"\,%l\,' . columnchar . '\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/php/phpcs.vim
+++ b/syntax_checkers/php/phpcs.vim
@@ -21,10 +21,8 @@ set cpo&vim
 function! SyntaxCheckers_php_phpcs_GetLocList() dict
     if &expandtab
         let args = '--tab-width=' . &tabstop
-        let columnchar = '%v'
     else
         let args = ''
-        let columnchar = '%c'
     endif
 
     let makeprg = self.makeprgBuild({
@@ -33,7 +31,7 @@ function! SyntaxCheckers_php_phpcs_GetLocList() dict
 
     let errorformat =
         \ '%-GFile\,Line\,Column\,Type\,Message\,Source\,Severity%.%#,'.
-        \ '"%f"\,%l\,' . columnchar . '\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
+        \ '"%f"\,%l\,%c\,%t%*[a-zA-Z]\,"%m"\,%*[a-zA-Z0-9_.-]\,%*[0-9]%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
This PR makes it so that when using the phpcs PHP linter, a couple of settings are dependent on whether expandtab is set. This fixes the use-case where tabs and not spaces are used to indent lines.