### PR TITLE
Make go.vim work with go 1.4 again

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -51,11 +51,11 @@ function! SyntaxCheckers_go_go_GetLocList() dict
     " compiled by `go build`, therefore `go test` must be called for those.
     if match(expand('%', 1), '\m_test\.go$') == -1
         let opts = syntastic#util#shescape(syntastic#util#var('go_go_build_args'))
-        let makeprg = self.getExec() . ' build ' . opts . ' ' . syntastic#c#NullOutput()
+        let makeprg = self.getExec() . ' build ' . syntastic#c#NullOutput() . ' ' . opts
         let cleanup = 0
     else
         let opts = syntastic#util#shescape(syntastic#util#var('go_go_test_args'))
-        let makeprg = self.getExec() . ' test -c ' . opts . ' ' . syntastic#c#NullOutput()
+        let makeprg = self.getExec() . ' test -c ' . syntastic#c#NullOutput() . ' ' . opts
         let cleanup = 1
     endif
 


### PR DESCRIPTION
The addition of 'opts' caused this code to render bad command lines like `go build '' -o /dev/null`, which caused go 1.4 to treat `-o` as a package, and then fail (producing no error output for syntastic :(). I didn't test this with 1.3, but I expect that it should still work.