### PR TITLE
Rubocop improvements

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -30,7 +30,11 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--format emacs --silent' })
+    let rubocop_args = '--format emacs'
+    if exists('g:syntastic_ruby_rubocop_args')
+        let rubocop_args .= ' '.g:syntastic_ruby_rubocop_args
+    endif
+    let makeprg = self.makeprgBuild({ 'args_after': rubocop_args })
 
     let errorformat = '%f:%l:%c: %t: %m'
 

--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -26,7 +26,7 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
     let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
     call self.log(self.getExec() . ' version =', ver)
 
-    return syntastic#util#versionIsAtLeast(ver, [0, 9, 0])
+    return syntastic#util#versionIsAtLeast(ver, [0, 12, 0])
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict


### PR DESCRIPTION
This pull request brings a couple of things here:

1. Removes `--silent` option since Rubocop >= 0.12 dropped it (and in [master](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes) throws error.
2. Allows to pass custom options to Rubocop (in my case it's `--display-cop-names` which is useful when initial config is being created)

If this is merged, I'll update wiki page accordingly.