### PR TITLE
Use codecs to read the python file

### DIFF
--- a/syntax_checkers/python/compile.py
+++ b/syntax_checkers/python/compile.py
@@ -2,12 +2,29 @@
 
 from __future__ import print_function
 from sys import argv, exit
-
+import codecs
+import re
+import os
 
 if len(argv) != 2:
     exit(1)
 
 try:
-    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
+    with open(argv[1]) as fle:
+        text = fle.readlines()
+
+    if text:
+        match = re.match("#\s*coding\s*:\s*(?P<coding>\w+)", text[0])
+        if match:
+            text = codecs.lookup(match.groupdict()["coding"]).incrementaldecoder().decode(''.join(text).encode('utf-8')).encode('utf-8')
+
+    if isinstance(text, list):
+        text = ''.join(text).encode('utf-8')
+
+    # from rpdb import set_trace; set_trace()
+    compile(text, argv[1], 'exec', 0, 1)
 except SyntaxError as err:
     print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
+except Exception as err:
+    print('%s:%s:%s: %s' % (os.path.abspath(argv[1]), 1, 0, err))
+


### PR DESCRIPTION
Hello,

I use this testing library I created called noseOfYeti (https://noseofyeti.readthedocs.org/en/latest/)

This library means that my tests use a codec that transforms the file at import time.

This pull request is to make the python checker aware of the codec (works generically with any codec specified at the top of a file) and syntax check the decoded file, rather than the raw file.

Stephen.
