### PR TITLE
Using flow server instead of `flow check`

### DIFF
--- a/syntax_checkers/javascript/flow.vim
+++ b/syntax_checkers/javascript/flow.vim
@@ -23,7 +23,7 @@ set cpo&vim
 
 function! SyntaxCheckers_javascript_flow_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'exe_after': 'check',
+        \ 'exe_after': 'status',
         \ 'args_after': '--show-all-errors --json' })
 
     let errorformat =


### PR DESCRIPTION
`flow check` is too slow on large projects, so it is preferable to use flow server with `flow status` command.