### PR TITLE
flow js checker - use 'flow' instead of 'flow check' for speed

### DIFF
--- a/syntax_checkers/javascript/flow.vim
+++ b/syntax_checkers/javascript/flow.vim
@@ -23,7 +23,7 @@ set cpo&vim
 
 function! SyntaxCheckers_javascript_flow_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'exe': self.getExecEscaped() . ' check',
+        \ 'exe': self.getExecEscaped(),
         \ 'args_after': '--show-all-errors --json' })
 
     let errorformat =


### PR DESCRIPTION
I changed the command from "flow check" to "flow"

Right now, my editor freezes for 2-3 seconds every time I save, because that's how long it takes to boot up the flow type checker. Flow is designed to turn on a type checking server once, which keeps track of file changes on its own. You run `flow` and if the server isn't on, it turns it on. Then you just run `flow` again and it reports updates. 

This PR removes "check", which makes subsequent type checks instant. The first time you save, it still freezes, but from then on it's great. I verified that it creates the server in the normal way (running flow in the terminal after saving doesn't start a second server). 

