### PR TITLE
add IsAvailable to rst2pseudoxml syntax check

### DIFF
--- a/syntax_checkers/rst/rst2pseudoxml.vim
+++ b/syntax_checkers/rst/rst2pseudoxml.vim
@@ -23,6 +23,14 @@ let s:rst2pseudoxml = executable('rst2pseudoxml.py') ? 'rst2pseudoxml.py' : 'rst
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! SyntaxCheckers_rst_rst2pseudoxml_IsAvailable() dict
+    if !executable(s:rst2pseudoxml)
+        return 1
+    endif
+
+    return 0
+endfunction
+
 function! SyntaxCheckers_rst_rst2pseudoxml_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'args_after': '--report=2 --exit-status=1',


### PR DESCRIPTION
If IsAvailable is absent, this checker will break when the program isn't available

Note: this needs further testing (for the case when the program *is* available).