### PR TITLE
python: Read python source as bytes

### DIFF
--- a/syntax_checkers/python/compile.py
+++ b/syntax_checkers/python/compile.py
@@ -8,6 +8,6 @@ if len(argv) != 2:
     exit(1)
 
 try:
-    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
+    compile(open(argv[1], 'rb').read(), argv[1], 'exec', 0, 1)
 except SyntaxError as err:
     print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))


### PR DESCRIPTION
Syntastic unsets LC_ALL when running commands, this leads to
`compile.py` dying horribly when encountering non-ascii characters in
source code running under Python 3.

Consuming the input source as bytes and passing this directly to
`compile` solves this: