### PR TITLE
map 'pe-puppet' to 'puppet' in register.vim

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -105,6 +105,7 @@ let s:_DEFAULT_FILETYPE_MAP = {
         \ 'litcoffee': 'coffee',
         \ 'mail': 'text',
         \ 'mkd': 'markdown',
+        \ 'pe-puppet': 'puppet',
         \ 'sgml': 'docbk',
         \ 'sgmllnx': 'docbk',
     \ }


### PR DESCRIPTION
In some cases vim will set the filetype of *.pp files to 'pe-puppet' instead of 'puppet'. There is no functional difference so lets map 'pe-puppet' to 'puppet' so we can use the same default checkers.