### PR TITLE
fix typescript compiler emit output

### DIFF
--- a/syntax_checkers/typescript/tsc.vim
+++ b/syntax_checkers/typescript/tsc.vim
@@ -19,7 +19,7 @@ set cpo&vim
 function! SyntaxCheckers_typescript_tsc_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'args': '--module commonjs',
-        \ 'args_after': '--out ' . syntastic#util#DevNull() })
+        \ 'args_after': '--noEmit'})
 
     let errorformat =
         \ '%E%f %#(%l\,%c): error %m,' .


### PR DESCRIPTION
Syntastic will emit js file when checking TypeScript file. This is not a desirable behavior.

According to TypeScript [module specs](https://typescript.codeplex.com/wikipage?title=Modules%20in%20TypeScript), `--out` flags [should not](http://stackoverflow.com/a/27551407/2198656) be used with external module. So `--module commonjs` and `--out /dev/null` are two [mutually exclusiv](https://github.com/Microsoft/TypeScript/issues/1544#issuecomment-67781268) arguments.

This is not a problem with TypeScript compiler, because module loader specs require all files are [separated and imported by loader](https://github.com/Microsoft/TypeScript/issues/1544#issuecomment-69227334). So `--output` is not a valid option for checking.

However, tsc does provide a more straightforward option `--noEmit`, which is a more sensible alternative.
This also fixes https://github.com/scrooloose/syntastic/pull/1155