### PR TITLE
Ignore warning on checking rubocop's version

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
-    return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 12, 0])
+    return syntastic#util#versionIsAtLeast(self.getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull()), [0, 12, 0])
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict


### PR DESCRIPTION
Depends on installed ruby version, warning like below are appeared and syntastic cannot recognize rubocop's version.

```
$ rubocop --version
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.6-compliant syntax, but you are running 2.1.0.
0.30.0
```

This change fixes it.