### PR TITLE
Update url for tidy-html5

### DIFF
--- a/syntax_checkers/html/tidy.vim
+++ b/syntax_checkers/html/tidy.vim
@@ -13,7 +13,8 @@
 " Note: if you need to check HTML5 sources, you might consider installing a
 " fork of HTML Tidy, named "HTML Tidy for HTML5":
 "
-"   http://w3c.github.io/tidy-html5/
+"   http://www.html-tidy.org/
+"   https://github.com/htacg/tidy-html5
 "
 " HTML Tidy for HTML5 can be used without changes by this checker, just install
 " it and point g:syntastic_html_tidy_exec to the executable.


### PR DESCRIPTION
They moved to @htacg, the "HTML Tidy Advocacy Community Group".