### PR TITLE
First stab at YARD checker

### DIFF
--- a/syntax_checkers/ruby/yard.vim
+++ b/syntax_checkers/ruby/yard.vim
@@ -1,0 +1,58 @@
+"============================================================================
+"File:        yard.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Steve Loveless
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_ruby_yard_checker')
+    finish
+endif
+let g:loaded_syntastic_ruby_yard_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_ruby_yard_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+    return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 7, 0])
+endfunction
+
+function! SyntaxCheckers_ruby_yard_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': 'stats' })
+
+    " Lines that contain the error info
+    let errorformat = '%W[warn]: %m,%Z    in file `%f'' near line %l,'
+    let errorformat .= '%E[error]: %m,%Z    in file `%f'' near line %l'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat})
+
+    " Convert Yard severities to error types recognized by syntastic
+    for e in loclist
+        if e['type'] ==# 'e'
+            let e['type'] = 'E'
+        elseif e['type'] ==# 'w'
+            let e['type'] = 'W'
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'ruby',
+    \ 'name': 'yard'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/ruby/yard.vim
+++ b/syntax_checkers/ruby/yard.vim
@@ -36,15 +36,6 @@ function! SyntaxCheckers_ruby_yard_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat})
 
-    " Convert Yard severities to error types recognized by syntastic
-    for e in loclist
-        if e['type'] ==# 'e'
-            let e['type'] = 'E'
-        elseif e['type'] ==# 'w'
-            let e['type'] = 'W'
-        endif
-    endfor
-
     return loclist
 endfunction
 


### PR DESCRIPTION
This is for a checker that parses the output from [YARD](http://yardoc.org)'s `yard stats` command, which gives syntax warnings for its markup. It's a Ruby tool and I based it off of the Rubocop checker. I peeked at the guide and I think this should all be in line with that. I'm new to vim's `errorformat`, so suggestions are welcome.