### PR TITLE
Ignore stderr when getting rubocop version

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -22,6 +22,9 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
+    let ver = syntastic#util#parseVersion(syntastic#util#system(self.getExecEscaped() . ' --version 2>'. syntastic#util#DevNull()))
+    call self.setVersion(ver)
+
     return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 12, 0])
 endfunction
 


### PR DESCRIPTION
`rubocop --version` may emit a warning about parser versions not
matching.  Due to the way dependent libraries work, there isn't an
easy way to prevent this warning from showing up within rubocop itself.

Fixes #1145