### PR TITLE
Fix SyntasticLoclist.isNewerThan (Neovim, but in general)

### DIFF
--- a/plugin/syntastic/loclist.vim
+++ b/plugin/syntastic/loclist.vim
@@ -59,9 +59,16 @@ endfunction " }}}2
 function! g:SyntasticLoclist.isNewerThan(stamp) abort " {{{2
     if !exists('self._stamp')
         let self._stamp = []
+    endif
+    if a:stamp == []
+        return 1
+    endif
+    if self._stamp == []
         return 0
     endif
-    return syntastic#util#compareLexi(self._stamp, a:stamp) > 0
+    let [a_s, a_ms] = split(split(reltimestr(reltime(self._stamp)))[0], '\.')
+    let [b_s, b_ms] = split(split(reltimestr(reltime(a:stamp)))[0], '\.')
+    return a_s > b_s || (a_s == b_s && a_ms > b_ms)
 endfunction " }}}2
 
 function! g:SyntasticLoclist.copyRaw() abort " {{{2


### PR DESCRIPTION
`reltime()` returns a list of integers, where the second one might be
negative, e.g. `[0, -200945546]` (for 4.094022) seconds.

Using `syntastic#util#compareLexi` for comparison would return 0 in that
case, resulting in the notifiers not being called.

Since the second entry from `reltime()` is not always negative (or the first one might have advanced) this caused Syntastic to sometimes just not opening the location list with `g:syntastic_auto_loc_list = 1` and caused some other weird / not easily to reproduce issues probably.