### PR TITLE
Compile elixir rather than execute it.

### DIFF
--- a/syntax_checkers/elixir/elixir.vim
+++ b/syntax_checkers/elixir/elixir.vim
@@ -21,20 +21,14 @@ set cpo&vim
 " TODO: we should probably split this into separate checkers
 function! SyntaxCheckers_elixir_elixir_IsAvailable() dict
     call self.log(
-        \ 'executable("elixir") = ' . executable('elixir') . ', ' .
+        \ 'executable("elixirc") = ' . executable('elixirc') . ', ' .
         \ 'executable("mix") = ' . executable('mix'))
-    return executable('elixir') && executable('mix')
+    return executable('elixirc') && executable('mix')
 endfunction
 
 function! SyntaxCheckers_elixir_elixir_GetLocList() dict
-    if !exists('g:syntastic_enable_elixir_checker') || !g:syntastic_enable_elixir_checker
-        call syntastic#log#error('checker elixir/elixir: checks disabled for security reasons; ' .
-            \ 'set g:syntastic_enable_elixir_checker to 1 to override')
-        return []
-    endif
-
     let make_options = {}
-    let compile_command = 'elixir'
+    let compile_command = 'elixirc'
     let mix_file = syntastic#util#findInParent('mix.exs', expand('%:p:h', 1))
 
     if filereadable(mix_file)


### PR DESCRIPTION
Use `elixirc` to compile elixir files for syntax checks rather than
executing them with `elixir`.