### PR TITLE
javascript/flow: use 2nd location instead of first if available

### DIFF
--- a/syntax_checkers/javascript/flow.vim
+++ b/syntax_checkers/javascript/flow.vim
@@ -38,6 +38,7 @@ function! SyntaxCheckers_javascript_flow_GetLocList() dict
         \ 'args_after': '--show-all-errors --json' })
 
     let errorformat =
+        \ '%.%#: %m (%f:%l:%c\,%.%#),' .
         \ '%f:%l:%c:%n: %m,' .
         \ '%f:%l:%c: %m'
 


### PR DESCRIPTION
Right now, if you have this code: 

    type User = {name: string, age: number}

    // notice I forgot the age!
    var user:User = {name:"hello"} 

Flow reports an error that gives both the line number of the type, and of the object. Right now we're using the line number of the type, which is very confusing. 

I added another errorformat entry that will use the 2nd location when available so it correctly points to the object missing the property. 

----

Example: If we have this error from the preprocessor: 

    /Users/seanhess/projects/serials/web/app/model/source.js:20:22: property hidden Property not found in object literal (/Users/seanhess/projects/serials/web/app/model/source.js:94:10,106:3)

It will now result in this output in the location list: 

    web/app/model/source.js|94 col 10 error| property hidden Property not found in object literal [javascript/flow]

