### PR TITLE
use the sphinx "pseudoxml" builder as a syntax checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.pyc
 *.swp
 tags
 .DS_Store

--- a/README.markdown
+++ b/README.markdown
@@ -60,10 +60,10 @@ Haml, Haskell, Haxe, Handlebars, HSS, HTML, Java, JavaScript, JSON, JSX, LESS,
 Lex, Limbo, LISP, LLVM intermediate language, Lua, Markdown, MATLAB, Mercury,
 NASM, Nix, Objective-C, Objective-C++, OCaml, Perl, Perl POD, PHP, gettext
 Portable Object, OS X and iOS property lists, Puppet, Python, R, Racket, Relax
-NG, reStructuredText, RPM spec, Ruby, SASS/SCSS, Scala, Slim, SML, Tcl, TeX,
-Texinfo, Twig, TypeScript, Vala, Verilog, VHDL, VimL, xHtml, XML, XSLT, YACC,
-YAML, z80, Zope page templates, and zsh.  See the [wiki][3] for details about
-the corresponding supported checkers.
+NG, reStructuredText, RPM spec, Ruby, SASS/SCSS, Scala, Slim, SML, Sphinx, Tcl,
+TeX, Texinfo, Twig, TypeScript, Vala, Verilog, VHDL, VimL, xHtml, XML, XSLT,
+YACC, YAML, z80, Zope page templates, and zsh.  See the [wiki][3] for details
+about the corresponding supported checkers.
 
 A number of third-party Vim plugins also provide checkers for syntastic,
 for example: [omnisharp-vim][25], [rust.vim][12], [syntastic-extras][26],

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -69,7 +69,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'r':             [],
         \ 'racket':        ['racket'],
         \ 'rnc':           ['rnv'],
-        \ 'rst':           ['rst2pseudoxml'],
+        \ 'rst':           ['sphinx'],
         \ 'ruby':          ['mri'],
         \ 'sass':          ['sass'],
         \ 'scala':         ['fsc', 'scalac'],

--- a/syntax_checkers/rst/sphinx.vim
+++ b/syntax_checkers/rst/sphinx.vim
@@ -1,0 +1,72 @@
+"============================================================================
+"File:        sphinx.vim
+"Description: Syntax checking plugin for Sphinx reStructuredText files
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_rst_sphinx_checker")
+    finish
+endif
+let g:loaded_syntastic_rst_sphinx_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_rst_sphinx_GetLocList() dict
+
+    let srcdir = syntastic#util#var('rst_sphinx_source_dir')
+    if srcdir == ''
+        let config = findfile('conf.py', '.;')
+        if config == ''
+            return []
+        endif
+        let srcdir = fnamemodify(config, ':p:h')
+    endif
+
+    let confdir = syntastic#util#var('rst_sphinx_config_dir')
+    if confdir == ''
+        let config = findfile('conf.py', '.;')
+        let confdir = config != '' ? fnamemodify(config, ':p:h') : srcdir
+    endif
+
+    let tmpdir = syntastic#util#tmpdir()
+
+    let makeprg = self.makeprgBuild({
+        \ 'args': '-n',
+        \ 'args_after': '-q -E -N -b pseudoxml -c ' . syntastic#util#shescape(confdir),
+        \ 'fname': srcdir,
+        \ 'fname_after': tmpdir })
+
+    let errorformat =
+        \ '%f:%l: %tRROR: %m,' .
+        \ '%f:%l: %tARNING: %m,' .
+        \ '%f:: %tRROR: %m,' .
+        \ '%f:: %tARNING: %m,' .
+        \ '%trror: %m,' .
+        \ '%-G%.%#'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0] })
+
+    call syntastic#util#rmrf(tmpdir)
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'rst',
+    \ 'name': 'sphinx',
+    \ 'exec': 'sphinx-build' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This probably isn't 100% right, but it's a good starting point, and it works better for me than the existing rst checkers.

I believe this should be the preferred checker for python documentation, but I don't know how I would implement that.