### PR TITLE
Path substitution for g:syntastic_java_javac_custom_classpath_command

### DIFF
--- a/syntax_checkers/java/javac.vim
+++ b/syntax_checkers/java/javac.vim
@@ -129,7 +129,14 @@ function! SyntaxCheckers_java_javac_GetLocList() dict " {{{1
 
     " load custom classpath {{{2
     if g:syntastic_java_javac_custom_classpath_command !=# ''
-        let lines = syntastic#util#system(g:syntastic_java_javac_custom_classpath_command)
+        " Pre-process the classpath command string a little.
+        let classpath_command = g:syntastic_java_javac_custom_classpath_command
+        for sub in [['%FILE_PATH%', syntastic#util#shexpand('%:p')],
+                  \ ['%FILE_NAME%', syntastic#util#shexpand('%:t')],
+                  \ ['%FILE_DIR%',  syntastic#util#shexpand('%:p:h')]]
+            let classpath_command = substitute(classpath_command, sub[0], sub[1], 'g')
+        endfor
+        let lines = system(classpath_command)
         if syntastic#util#isRunningWindows() || has('win32unix')
             let lines = substitute(lines, "\r\n", "\n", 'g')
         endif


### PR DESCRIPTION
This patch allows `%FILE_PATH%`, `%FILE_NAME%` and `%FILE_DIR%` to be used in `g:syntastic_java_javac_custom_classpath_command` to refer to the current file's full path, basename, and directory, respectively.

This came about because I had written a helper script to build my Android SDK classpath by inspecting the build files in the project directory for the API target. Problem was if I didn't `cd` into the project directory before starting Vim, or if I had files from multiple projects open, the script wouldn't know which project to inspect because it couldn't know what file it was building a classpath for.