### PR TITLE
throw an easier-to-read error when a user has tried to enable a checker but messed up the config

### DIFF
--- a/plugin/syntastic/checker.vim
+++ b/plugin/syntastic/checker.vim
@@ -85,6 +85,11 @@ function! g:SyntasticChecker.getLocListRaw() abort " {{{2
 
     if has_key(self, '_enable')
         let status = syntastic#util#var(self._enable, -1)
+        if type(status) != type(0)
+            call syntastic#log#error('checker ' . name . ': checks disabled due to bad config: ' .
+                \ 'set g:syntastic_' . self._enable . ' to an integer')
+            return []
+        endif
         if status < 0
             call syntastic#log#error('checker ' . name . ': checks disabled for security reasons; ' .
                 \ 'set g:syntastic_' . self._enable . ' to 1 to override')


### PR DESCRIPTION
I am not sure you'll think this is necessary, but it would have saved me some angst yesterday wondering what was going wrong after I tried to enable a checker with a list instead of a 1:
```
Error detected while processing function <SNR>55_BufWritePostHook..<SNR>55_UpdateErrors..<SNR>55_Cache
Errors..240..239:
line    5:
E691: Can only compare List with List
E15: Invalid expression: status < 0
Error detected while processing function <SNR>55_BufWritePostHook..<SNR>55_UpdateErrors..<SNR>55_Cache
Errors..240..262:
line    3:
E712: Argument of filter() must be a List or Dictionary
```