### PR TITLE
New checker for qml: qmllint

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -66,6 +66,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'pod':           ['podchecker'],
         \ 'puppet':        ['puppet', 'puppetlint'],
         \ 'python':        ['python', 'flake8', 'pylint'],
+        \ 'qml':           ['qmllint'],
         \ 'r':             [],
         \ 'racket':        ['racket'],
         \ 'rnc':           ['rnv'],

--- a/syntax_checkers/qml/qmllint.vim
+++ b/syntax_checkers/qml/qmllint.vim
@@ -1,0 +1,41 @@
+"============================================================================
+"File:        qmllint.vim
+"Description: Syntax checking plugin for syntastic.vim using qmllint
+"Maintainer:  Peter Wu <peter@lekensteyn.nl>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_qml_qmllint_checker')
+    finish
+endif
+let g:loaded_syntastic_qml_qmllint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_qml_qmllint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    " Supported error formats can be found in
+    " qt-everywhere-opensource-src-5.5.0/qtdeclarative/tools/qmllint/main.cpp
+    let errorformat =
+        \ '%E%f:%l : %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 255] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'qml',
+    \ 'name': 'qmllint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Note that some syntax errors generate a line number past the last line:

    file.qml:2 : Expected token `}'

(Example contents: `Item {`)

Then unfortunately no marker is displayed on the side. I observed this with other file types as well. Maybe GetLocList should check whether a generated line number equals `n + 1` for `n` line numbers, and in that case set the line number to `n` instead (but only if no error exists at that line). Hmm.