### PR TITLE
tslint: The -f option is no longer available

### DIFF
--- a/syntax_checkers/typescript/tslint.vim
+++ b/syntax_checkers/typescript/tslint.vim
@@ -22,9 +22,7 @@ function! SyntaxCheckers_typescript_tslint_GetHighlightRegex(item)
 endfunction
 
 function! SyntaxCheckers_typescript_tslint_GetLocList() dict
-    let makeprg = self.makeprgBuild({
-        \ 'args_after': '--format verbose',
-        \ 'fname_before': '-f' })
+    let makeprg = self.makeprgBuild({'args_after': '--format verbose'})
 
     " (comment-format) ts/app.ts[12, 36]: comment must start with lowercase letter
     let errorformat = '%f[%l\, %c]: %m'


### PR DESCRIPTION
```bash
$ tslint --format verbose -f foo.ts bar.ts
usage: /usr/local/bin/tslint

Options:
  -c, --config          configuration file
  -h, --help            display detailed help
  -o, --out             output file
  -r, --rules-dir       rules directory
  -s, --formatters-dir  formatters directory
  -t, --format          output format (prose, json, verbose)  [default: "prose"]
  -v, --version         current version

-f option is no longer available. Supply files directly to the tslint command instead.
```