### PR TITLE
Suppresses Rubocop warnings to get accurate version

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -22,7 +22,8 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
-    return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 12, 0])
+    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull())
+    return syntastic#util#versionIsAtLeast(ver, [0, 12, 0])
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict


### PR DESCRIPTION
Hello,

First of all, thank you so much for this awesome tool! :beers: 

I've noticed my Rubocop install outputs this warning:
```bash
$ rubocop --version
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.7-compliant syntax, but you are running 2.1.6.
0.32.0
```

Which messes up the `getVersion` function.

Because there's [no flag in Rubocop to hide such warnings](https://github.com/bbatsov/rubocop/issues/1819), I've ignored them like it's done in [coffee.vim](https://github.com/scrooloose/syntastic/blob/a7fde99ea9a4eb26e6dfedb3ea54bbeefb71b325/syntax_checkers/coffee/coffee.vim#L28-L29)

Please let me know if there's anything else I can/should do.

Thanks!