### PR TITLE
fix jshint and jsxhint loading error

### DIFF
--- a/syntax_checkers/html/jshint.vim
+++ b/syntax_checkers/html/jshint.vim
@@ -23,7 +23,8 @@ function! SyntaxCheckers_html_jshint_IsAvailable() dict
         return 0
     endif
 
-    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
+    let command = self.getExecEscaped() . ' --version'
+    let ver = self.getVersion(syntastic#util#isRunningWindows() ? command : (command . ' 2>&1'))
     return syntastic#util#versionIsAtLeast(ver, [2, 4])
 endfunction
 

--- a/syntax_checkers/html/jshint.vim
+++ b/syntax_checkers/html/jshint.vim
@@ -22,7 +22,9 @@ function! SyntaxCheckers_html_jshint_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
-    return syntastic#util#versionIsAtLeast(self.getVersion(), [2, 4])
+
+    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
+    return syntastic#util#versionIsAtLeast(ver, [2, 4])
 endfunction
 
 function! SyntaxCheckers_html_jshint_GetLocList() dict

--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -27,7 +27,7 @@ function! SyntaxCheckers_javascript_jshint_IsAvailable() dict
         return 0
     endif
 
-    let ver = self.getVersion()
+    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
     let s:jshint_new = syntastic#util#versionIsAtLeast(ver, [1, 1])
 
     return syntastic#util#versionIsAtLeast(ver, [1])

--- a/syntax_checkers/javascript/jshint.vim
+++ b/syntax_checkers/javascript/jshint.vim
@@ -27,7 +27,8 @@ function! SyntaxCheckers_javascript_jshint_IsAvailable() dict
         return 0
     endif
 
-    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
+    let command = self.getExecEscaped() . ' --version'
+    let ver = self.getVersion(syntastic#util#isRunningWindows() ? command : (command . ' 2>&1'))
     let s:jshint_new = syntastic#util#versionIsAtLeast(ver, [1, 1])
 
     return syntastic#util#versionIsAtLeast(ver, [1])

--- a/syntax_checkers/javascript/jsxhint.vim
+++ b/syntax_checkers/javascript/jsxhint.vim
@@ -22,7 +22,8 @@ function! SyntaxCheckers_javascript_jsxhint_IsAvailable() dict
         return 0
     endif
 
-    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
+    let command = self.getExecEscaped() . ' --version'
+    let ver = self.getVersion(syntastic#util#isRunningWindows() ? command : (command . ' 2>&1'))
     return syntastic#util#versionIsAtLeast(ver, [0, 4, 1])
 endfunction
 

--- a/syntax_checkers/javascript/jsxhint.vim
+++ b/syntax_checkers/javascript/jsxhint.vim
@@ -22,16 +22,8 @@ function! SyntaxCheckers_javascript_jsxhint_IsAvailable() dict
         return 0
     endif
 
-    let version_output = syntastic#util#system(self.getExecEscaped() . ' --version')
-    let parsed_ver = !v:shell_error && (version_output =~# '\m^JSXHint\>') ? syntastic#util#parseVersion(version_output) : []
-    if len(parsed_ver)
-        call self.setVersion(parsed_ver)
-    else
-        call syntastic#log#ndebug(g:_SYNTASTIC_DEBUG_LOCLIST, 'checker output:', split(version_output, "\n", 1))
-        call syntastic#log#error("checker javascript/jsxhint: can't parse version string (abnormal termination?)")
-    endif
-
-    return syntastic#util#versionIsAtLeast(parsed_ver, [0, 4, 1])
+    let ver = self.getVersion(self.getExecEscaped() . ' --version 2>&1')
+    return syntastic#util#versionIsAtLeast(ver, [0, 4, 1])
 endfunction
 
 function! SyntaxCheckers_javascript_jsxhint_GetLocList() dict


### PR DESCRIPTION
In OSX and Linux, jshint and jsxhint put their version string output in stderr instead of stdout.
Therefore, ```system('jshint --version')``` return empty value, which ends up being a version parse error.
```syntastic: error: checker javascript/jshint: can't parse version string (abnormal termination?)```
Of course, Windows environment don't have this issue.