### PR TITLE
Set the GOGC env var to off to speed up go builds

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -77,6 +77,7 @@ function! SyntaxCheckers_go_go_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'cwd': expand('%:p:h', 1),
+        \ 'env': {'GOGC': 'off'},
         \ 'defaults': {'type': 'e'} })
 
     if cleanup


### PR DESCRIPTION
With GO 1.5, builds are up to 2x slower, so this becomes really important. It
was suggested on https://twitter.com/mitchellh/status/634419559252914176