### PR TITLE
gotype - parse package test files if checking a test file

### DIFF
--- a/syntax_checkers/go/gotype.vim
+++ b/syntax_checkers/go/gotype.vim
@@ -19,7 +19,13 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_go_gotype_GetLocList() dict
-    let makeprg = self.getExecEscaped() . ' .'
+    if match(expand('%', 1), '\m_test\.go$') == -1
+        let opts = ''
+    else
+        let opts = ' -a'
+    endif
+
+    let makeprg = self.getExecEscaped() . opts . ' .'
 
     let errorformat =
         \ '%f:%l:%c: %m,' .


### PR DESCRIPTION
gotype wasn't parsing `_test.go` files, which is fine most of the time - except when you were writing test files :)

This pr passes the flag `-a` to `gotype` if we're currently on a `_test.go` file. 

From the `gotype` usage:

```
  -a=false: use all (incl. _test.go) files when processing a directory
```