### PR TITLE
Add jade-lint

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -42,6 +42,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'haxe':          ['haxe'],
         \ 'hss':           ['hss'],
         \ 'html':          ['tidy'],
+        \ 'jade':          ['jade_lint'],
         \ 'java':          ['javac'],
         \ 'javascript':    ['jshint', 'jslint'],
         \ 'json':          ['jsonlint', 'jsonval'],

--- a/syntax_checkers/jade/jade_lint.vim
+++ b/syntax_checkers/jade/jade_lint.vim
@@ -1,0 +1,43 @@
+"============================================================================
+"File:        jade_lint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Ben Parnell <benjaminparnell.94@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_jade_jade_lint_checker')
+    finish
+endif
+let g:loaded_syntastic_jade_jade_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_jade_jade_lint_IsAvailable() dict
+  return executable('jade-lint')
+endfunction
+
+function! SyntaxCheckers_jade_jade_lint_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'exe': 'jade-lint', 'args': '-r inline' })
+
+    let errorformat = '%f:%l:%c %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'jade',
+    \ 'name': 'jade_lint',
+    \ 'exe': 'jade-lint',
+    \ 'returns': [0, 2] })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This adds [jade-lint](https://github.com/benedfit/jade-lint), a syntax checker for [jade](http://jade-lang.com/) templates.