### PR TITLE
Skip ignored files in BufEnterHook

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -270,6 +270,11 @@ function! s:BufEnterHook() abort " {{{2
     call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
         \ 'autocmd: BufEnter, buffer ' . bufnr('') . ' = ' . string(bufname(str2nr(bufnr('')))) .
         \ ', &buftype = ' . string(&buftype))
+
+    if s:_skip_file()
+        return
+    endif
+
     if &buftype ==# ''
         call s:notifiers.refresh(g:SyntasticLoclist.current())
     elseif &buftype ==# 'quickfix'


### PR DESCRIPTION
Without this an existing location list would pop up again, although
`b:syntastic_skip_checks` is set to 1 (after the list has been created
initially).