### PR TITLE
Hlint: handle hint file parsing errors.

### DIFF
--- a/syntax_checkers/haskell/hlint.vim
+++ b/syntax_checkers/haskell/hlint.vim
@@ -18,6 +18,7 @@ function! SyntaxCheckers_haskell_hlint_GetLocList() dict
         \ 'fname': syntastic#util#shexpand('%:p')})
 
     let errorformat =
+        \ '%E%f:%l:%v: Error while reading hint file\, %m,' .
         \ '%E%f:%l:%v: Error: %m,' .
         \ '%W%f:%l:%v: Warning: %m,' .
         \ '%C%m'


### PR DESCRIPTION
When hints (including those in ANN pragmas in Haskell source) fail to
parse, Hlint uses a different error format. As parse errors are fatal, ignoring
them effectively mutes the checker.