### PR TITLE
JavaScript checkers: Add eslint_d checker

### DIFF
--- a/syntax_checkers/javascript/eslint_d.vim
+++ b/syntax_checkers/javascript/eslint_d.vim
@@ -1,0 +1,44 @@
+"============================================================================
+"File:        eslint_d.vim
+"Description: Javascript syntax checker - using eslint
+"Maintainer:  Maximilian Antoni
+"License:     MIT <https://github.com/mantoni/eslint_d.js/blob/master/LICENSE>
+"============================================================================
+
+if exists('g:loaded_syntastic_javascript_eslint_d_checker')
+    finish
+endif
+let g:loaded_syntastic_javascript_eslint_d_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_javascript_eslint_d_IsAvailable() dict
+    if executable(self.getExec())
+        return 1
+    endif
+    return 0
+endfunction
+
+function! SyntaxCheckers_javascript_eslint_d_GetLocList() dict
+    let makeprg = self.makeprgBuild({'fname_before': '--format compact'})
+
+    let errorformat =
+        \ '%E%f: line %l\, col %c\, Error - %m,' .
+        \ '%W%f: line %l\, col %c\, Warning - %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat})
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'javascript',
+    \ 'name': 'eslint_d'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
The eslint_d checker is essentially an eslint checker on steroids. It launches a daemon process in the background to only read all the node modules once. This brings the execution times down significantly.

Have a look at the README for more on how eslint_d works: https://www.npmjs.com/package/eslint_d

I'm new to vimscript and would be glad to hear your suggestions. I tried to stay close to the existing eslint checker. Thanks!