### PR TITLE
API Blueprint should use drafter

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -8,7 +8,7 @@ let g:loaded_syntastic_registry = 1
 let s:_DEFAULT_CHECKERS = {
         \ 'actionscript':  ['mxmlc'],
         \ 'ada':           ['gcc'],
-        \ 'apiblueprint':  ['snowcrash'],
+        \ 'apiblueprint':  ['drafter'],
         \ 'applescript':   ['osacompile'],
         \ 'asciidoc':      ['asciidoc'],
         \ 'asm':           ['gcc'],

--- a/syntax_checkers/apiblueprint/drafter.vim
+++ b/syntax_checkers/apiblueprint/drafter.vim
@@ -1,5 +1,5 @@
 "============================================================================
-"File:        snowcrash.vim
+"File:        drafter.vim
 "Description: Syntax checking plugin for syntastic.vim
 "Maintainer:  LCD 47 <lcd047 at gmail dot com>
 "License:     This program is free software. It comes without any warranty,
@@ -10,19 +10,19 @@
 "
 "============================================================================
 
-if exists('g:loaded_syntastic_apiblueprint_snowcrash_checker')
+if exists('g:loaded_syntastic_apiblueprint_drafter_checker')
     finish
 endif
-let g:loaded_syntastic_apiblueprint_snowcrash_checker = 1
+let g:loaded_syntastic_apiblueprint_drafter_checker = 1
 
-if !exists('g:syntastic_apiblueprint_snowcrash_sort')
-    let g:syntastic_apiblueprint_snowcrash_sort = 1
+if !exists('g:syntastic_apiblueprint_drafter_sort')
+    let g:syntastic_apiblueprint_drafter_sort = 1
 endif
 
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! SyntaxCheckers_apiblueprint_snowcrash_GetLocList() dict
+function! SyntaxCheckers_apiblueprint_drafter_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'post_args': '-u -l' })
 
     let errorformat =
@@ -58,7 +58,7 @@ endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'apiblueprint',
-    \ 'name': 'snowcrash'})
+    \ 'name': 'drafter'})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This is currently using the `snowcrash` command line tool which has been [non-existent since March](https://github.com/apiaryio/snowcrash/releases/tag/v1.0.0). and replaced in favour of [Drafter](https://github.com/apiaryio/drafter).