### PR TITLE
Update exit codes for drafter

### DIFF
--- a/syntax_checkers/apiblueprint/drafter.vim
+++ b/syntax_checkers/apiblueprint/drafter.vim
@@ -34,7 +34,7 @@ function! SyntaxCheckers_apiblueprint_drafter_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr('')},
-        \ 'returns': [0, 2] })
+        \ 'returns': [0, 2, 3, 4] })
 
     for e in loclist
         let matches = matchlist(e['text'], '\v^(.+); line (\d+), column (\d+) - line (\d+), column (\d+)$')


### PR DESCRIPTION
`drafter` may return underlying errors from `snowcrash` it's internal library for parsing for various reasons.

I've updated the list in syntastic to include any blueprint error.

List of exit codes can be found at https://github.com/apiaryio/snowcrash/blob/master/src/SourceAnnotation.h#L100-L106. I've intentionally left out ApplicationError (1) as this would be an application error and not a blueprint error.

Thanks :octocat:.