### PR TITLE
only show errors for mlint

### DIFF
--- a/syntax_checkers/matlab/mlint.vim
+++ b/syntax_checkers/matlab/mlint.vim
@@ -19,7 +19,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_matlab_mlint_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '-id $*' })
+    let makeprg = self.makeprgBuild({ 'args_after': '-m2 -id $*' })
 
     let errorformat =
         \ 'L %l (C %c): %*[a-zA-Z0-9]: %m,'.


### PR DESCRIPTION
It is VERY annoying to see warnings in MATLAB, since it tends to give so much (e.g. an explicit [1:3] will warning you that it is not necessary).
But explicity should never be a crime.

Looked at all MATLAB's official doc and several other mlint.vim implementations out there, I found from the Undocumented MATLAB website [here][1] how to turn it off. I believe that is what ALL matlab users want. But I would say having a `g:syntastic_matlab_mlint_checker_warnings` that controls this behavior would be nice. But I know almost nothing about vim scripts; all I do is to change my `.vimrc`. 

Here is the block from the website:

```matlab
% Note that mlint returns struct arrays, so the following are all structs, not strings
errMsgs = mlint('-m2',srcFileNames); % m2 = errors only
m1Msgs  = mlint('-m1',srcFileNames); % m1 = errors and severe warnings only
allMsgs = mlint('-m0',srcFileNames); % m0 = all errors and warnings
```

[1] http://undocumentedmatlab.com/blog/parsing-mlint-code-analyzer-output
[1]: http://undocumentedmatlab.com/blog/parsing-mlint-code-analyzer-output