### PR TITLE
Add support for Icarus Verilog compiler

### DIFF
--- a/syntax_checkers/verilog/iverilog.vim
+++ b/syntax_checkers/verilog/iverilog.vim
@@ -9,22 +9,22 @@ if exists('g:loaded_syntastic_verilog_iverilog_checker')
 endif
 let g:loaded_syntastic_verilog_iverilog_checker = 1
 
-if !exists('g:syntastic_verilog_compiler_options')
-    let g:syntastic_verilog_compiler_options = '-Wall'
-endif
-
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_verilog_iverilog_GetLocList() dict
-    if !exists('g:syntastic_verilog_compiler')
-        let g:syntastic_verilog_compiler = self.getExec()
-    endif
-    return syntastic#c#GetLocList('verilog', 'iverilog', {
-        \ 'errorformat':
+    let makeprg = self.makeprgBuild({
+                \ 'args_before': '-t null',
+                \ 'args': '-Wall' })
+
+    let errorformat =
         \     '%f:%l: %trror: %m,' .
-        \     '%f:%l: %tarning: %m',
-        \ 'main_flags': '-t null' })
+        \     '%f:%l: %tarning: %m,' .
+        \     '%E%f:%l:      : %m,' .
+        \     '%W%f:%l:        : %m,' .
+        \     '%f:%l: %m'
+
+    return SyntasticMake({'makeprg': makeprg, 'errorformat': errorformat})
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/syntax_checkers/verilog/iverilog.vim
+++ b/syntax_checkers/verilog/iverilog.vim
@@ -2,6 +2,7 @@
 "File:        iverilog.vim
 "Description: Syntax checking plugin for syntastic.vim
 "Maintainer:  Psidium <psiidium at gmail dot com>
+"License:     The MIT License
 "============================================================================
 
 if exists('g:loaded_syntastic_verilog_iverilog_checker')

--- a/syntax_checkers/verilog/iverilog.vim
+++ b/syntax_checkers/verilog/iverilog.vim
@@ -1,0 +1,37 @@
+"============================================================================
+"File:        iverilog.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Psidium <psiidium at gmail dot com>
+"============================================================================
+
+if exists('g:loaded_syntastic_verilog_iverilog_checker')
+    finish
+endif
+let g:loaded_syntastic_verilog_iverilog_checker = 1
+
+if !exists('g:syntastic_verilog_compiler_options')
+    let g:syntastic_verilog_compiler_options = '-Wall'
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_verilog_iverilog_GetLocList() dict
+    if !exists('g:syntastic_verilog_compiler')
+        let g:syntastic_verilog_compiler = self.getExec()
+    endif
+    return syntastic#c#GetLocList('verilog', 'iverilog', {
+        \ 'errorformat':
+        \     '%f:%l: %trror: %m,' .
+        \     '%f:%l: %tarning: %m',
+        \ 'main_flags': '-t null' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'verilog',
+    \ 'name': 'iverilog'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
For my CS class I needed to use this compiler for Verilog and my favourite editor/syntax checker didn't have support for it, so, instead of doing my assignment for my class, I've added support for it :smile:, now I'm uploading it back to the community. 
This new syntax checker is based on `verilator.vim`.
I've read `contributing.md` and I don't see any errors in my patch.

Also, I'd like to note that this task got SO easy once I discovered `let g:syntastic_debug = 3`, congratulation on such an epic project like this :heart_eyes: 