### PR TITLE
Added support for XQuery using BaseX.exe

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -95,6 +95,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'xhtml':         ['tidy'],
         \ 'xml':           ['xmllint'],
         \ 'xslt':          ['xmllint'],
+        \ 'xquery':        ['basex'],
         \ 'yacc':          ['bison'],
         \ 'yaml':          ['jsyaml'],
         \ 'z80':           ['z80syntaxchecker'],

--- a/syntax_checkers/xquery/basex.vim
+++ b/syntax_checkers/xquery/basex.vim
@@ -1,0 +1,50 @@
+"============================================================================
+"File:        basex.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  James Wright <james dot jw at hotmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_xquery_basex_checker')
+    finish
+endif
+let g:loaded_syntastic_xquery_basex_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+if exists('g:syntastic_extra_filetypes')
+    call add(g:syntastic_extra_filetypes, 'xquery')
+else
+    let g:syntastic_extra_filetypes = ['xquery']
+endif
+
+function SyntaxCheckers_xquery_basex_IsAvailable() dict
+    return executable(expand(self.getExec(), 1))
+endfunction
+
+function SyntaxCheckers_xquery_basex_GetLocList() dict
+    let makeprg = 'basex -z -q "inspect:module(' . "'" . expand("%:p") . "')" . '"'
+    let errorformat =
+        \ '%-GStopped at .\, %l/%c:,'.
+        \ '%E[%.%#] Stopped at %f\, %l/%c:,'.
+        \ '%Z[%t%#%n] %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat
+        \ })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'xquery',
+    \ 'name': 'basex'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
#### XQuery Syntastic Checker 
I have been using this checker without issue for a while and thought it was about time to share it.

##### Support
Works with [BaseX][0] for validating XQuery version 1.0 through 3.1

###### Install
1) Install BaseX
2) Add the ``basex/bin`` folder to your path.

Enjoy!

[0]: http://www.basex.org