### PR TITLE
Improve clang diagnostics, support compilation database

### DIFF
--- a/syntax_checkers/c/clang_check.vim
+++ b/syntax_checkers/c/clang_check.vim
@@ -22,24 +22,34 @@ if !exists('g:syntastic_c_clang_check_sort')
     let g:syntastic_c_clang_check_sort = 1
 endif
 
+if !exists('g:syntastic_c_clang_check_database')
+    let g:syntastic_c_clang_check_database = ''
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_c_clang_check_GetLocList() dict
+    if g:syntastic_c_clang_check_database == ''
+        let l:extra_args = '-- ' .
+        \   syntastic#c#ReadConfig(g:syntastic_clang_check_config_file)
+    else
+        let l:extra_args = '-p=' . g:syntastic_c_clang_check_database
+    endif
     let makeprg = self.makeprgBuild({
         \ 'post_args':
-        \   '-- ' .
-        \   syntastic#c#ReadConfig(g:syntastic_clang_check_config_file) . ' ' .
-        \   '-fshow-column ' .
-        \   '-fshow-source-location ' .
-        \   '-fno-caret-diagnostics ' .
-        \   '-fno-color-diagnostics ' .
-        \   '-fdiagnostics-format=clang' })
+        \   '-extra-arg=-fshow-column ' .
+        \   '-extra-arg=-fshow-source-location ' .
+        \   '-extra-arg=-fno-caret-diagnostics ' .
+        \   '-extra-arg=-fno-color-diagnostics ' .
+        \   '-extra-arg=-fdiagnostics-format=clang ' .
+        \   l:extra_args })
 
     let errorformat =
         \ '%E%f:%l:%c: fatal error: %m,' .
         \ '%E%f:%l:%c: error: %m,' .
         \ '%W%f:%l:%c: warning: %m,' .
+        \ '%W%f:%l:%c: note: %m,' .
         \ '%-G%\m%\%%(LLVM ERROR:%\|No compilation database found%\)%\@!%.%#,' .
         \ '%E%m'
 

--- a/syntax_checkers/c/clang_tidy.vim
+++ b/syntax_checkers/c/clang_tidy.vim
@@ -22,24 +22,34 @@ if !exists('g:syntastic_c_clang_tidy_sort')
     let g:syntastic_c_clang_tidy_sort = 1
 endif
 
+if !exists('g:syntastic_c_clang_tidy_database')
+    let g:syntastic_c_clang_tidy_database = ''
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_c_clang_tidy_GetLocList() dict
+    if g:syntastic_c_clang_tidy_database == ''
+        let l:extra_args = '-- ' .
+        \   syntastic#c#ReadConfig(g:syntastic_clang_tidy_config_file)
+    else
+        let l:extra_args = '-p=' . g:syntastic_c_clang_tidy_database
+    endif
     let makeprg = self.makeprgBuild({
         \ 'post_args':
-        \   '-- ' .
-        \   syntastic#c#ReadConfig(g:syntastic_clang_tidy_config_file) . ' ' .
-        \   '-fshow-column ' .
-        \   '-fshow-source-location ' .
-        \   '-fno-caret-diagnostics ' .
-        \   '-fno-color-diagnostics ' .
-        \   '-fdiagnostics-format=clang' })
+        \   '-extra-arg=-fshow-column ' .
+        \   '-extra-arg=-fshow-source-location ' .
+        \   '-extra-arg=-fno-caret-diagnostics ' .
+        \   '-extra-arg=-fno-color-diagnostics ' .
+        \   '-extra-arg=-fdiagnostics-format=clang ' .
+        \   l:extra_args })
 
     let errorformat =
         \ '%E%f:%l:%c: fatal error: %m,' .
         \ '%E%f:%l:%c: error: %m,' .
         \ '%W%f:%l:%c: warning: %m,' .
+        \ '%W%f:%l:%c: note: %m,' .
         \ '%-G%\m%\%%(LLVM ERROR:%\|No compilation database found%\)%\@!%.%#,' .
         \ '%E%m'
 


### PR DESCRIPTION
Two fixes (in one patch):
___
Propagate informational messages from clang, this can be useful for
syntax errors:

    packet-ssl-utils.c:6799:4: error: expected '}'
    packet-ssl-utils.c:6778:1: note: to match this '{'
___
Clearing g:syntastic_c_clang_check_post_args as documented on the wiki
does not work when colorful diagnostics are enabled (the output is not
recognized). Fix this by adding a new option for the compilation
database path that preserves the formatting options.
___
If this patch is approved, the wiki must also be updated:
https://github.com/scrooloose/syntastic/wiki/C%3A---clang_check