### PR TITLE
Add dockerfile-lint checker

### DIFF
--- a/syntax_checkers/dockerfile/dockerfile-lint.vim
+++ b/syntax_checkers/dockerfile/dockerfile-lint.vim
@@ -1,0 +1,42 @@
+"============================================================================
+"File:        dockerfile_lint.vim
+"Description: Syntax checking plugin for syntastic.vim using `dockerfile-lint`
+"             (https://github.com/projectatomic/dockerfile-lint).
+"Maintainer:  Tim Carry <tim at pixelastic dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+"
+if exists('g:loaded_syntastic_dockerfile_dockerfile_lint_checker')
+    finish
+endif
+let g:loaded_syntastic_dockerfile_dockerfile_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_dockerfile_dockerfile_lint_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+      \ 'args': '--json -f' })
+
+    let errorformat = '%t:%l:%m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')},
+        \ 'preprocess': 'dockerfile_lint' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'dockerfile',
+    \ 'name': 'dockerfile_lint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This adds a syntaxchecker for `Dockerfile`. This uses [dockerfile-lint](https://github.com/projectatomic/dockerfile_lint) and expect the `dockerfile-lint` binary to be available (usually through a `npm -g` install).

By default, it will simply check for basic syntax correctness of the `Dockerfile`. One can pass a custom  `yml` rule file through the `syntastic_dockerfile_dockerfile_lint_post_args`, for example:

```vim
let b:syntastic_dockerfile_dockerfile_lint_post_args = '-r /path/to/rule/file.yml'
```

I've used `preprocess` for the json parsing part.