### PR TITLE
Add slim-lint checker

### DIFF
--- a/syntax_checkers/slim/slim_lint.vim
+++ b/syntax_checkers/slim/slim_lint.vim
@@ -1,0 +1,43 @@
+"============================================================================
+"File:        slim_lint.vim
+"Description: Slim style and syntax checker plugin for Syntastic
+"Maintainer:  Vasily Kolesnikov <re.vkolesnikov@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_slim_slim_lint_checker')
+    finish
+endif
+let g:loaded_syntastic_slim_slim_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_slim_slim_lint_IsAvailable() dict
+    return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_slim_slim_lint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f:%l [%t] %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style'})
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'slim',
+    \ 'name': 'slim_lint',
+    \ 'exec': 'slim-lint' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This adds a syntaxchecker for *.slim files. This uses slim-lint
(https://github.com/sds/slim-lint) and expect the slim-lint binary to be
available (usually through a `gem install slim_lint`)