### PR TITLE
Syntax Checker: Add rudimentary support for .travis.yml files with syntax=travisci

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -88,6 +88,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'tex':           ['lacheck', 'chktex'],
         \ 'texinfo':       ['makeinfo'],
         \ 'text':          [],
+        \ 'travisci':      ['travis'],
         \ 'twig':          ['twiglint'],
         \ 'typescript':    ['tsc'],
         \ 'vala':          ['valac'],

--- a/syntax_checkers/travisci/travis.vim
+++ b/syntax_checkers/travisci/travis.vim
@@ -1,0 +1,39 @@
+"============================================================================
+"File:        travisci.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Authors:     Joel Frederico <joelfred at slac dot stanford dot edu>
+"
+"============================================================================
+if exists('g:loaded_syntastic_travisci_travis_checker')
+    finish
+endif
+let g:loaded_syntastic_travisci_travis_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_travisci_travis_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+                \ 'args': 'lint',
+                \ 'args_after': '' })
+
+    let errorformat = 
+        \ '[x] syntax error: (<unknown>): %m at line %l column %c,' .
+	\ '[x] %m,'
+	" \ '[x] %m %s\, dropping,' .
+
+
+    let env = {}
+
+    let loclist = SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'env': env })
+
+    for e in loclist
+    endfor
+
+    return loclist
+endfunction
+
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'travisci',
+    \ 'name': 'travis'})


### PR DESCRIPTION
Travis CI has a configuration file .travis.yml. (See https://github.com/travis-ci/travis.rb#lint) Assuming the user has set the syntax to travisci, we can use the 'travis lint' command to check the file.

However, this checker is rather awful. It isn't designed to be parsed and this issue has been closed with wontfix: https://github.com/travis-ci/travis.rb/issues/203.

But I think this is better than nothing.