### PR TITLE
Add mixedindentlint checker for JavaScript, scss, and css

### DIFF
--- a/syntax_checkers/css/mixedindentlint.vim
+++ b/syntax_checkers/css/mixedindentlint.vim
@@ -1,0 +1,22 @@
+"============================================================================
+"File:        mixedindentlint.vim
+"Description: Mixed indentation linter for vim
+"Maintainer:  Payton Swick <payton@foolord.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_css_mixedindentlint_checker')
+    finish
+endif
+let g:loaded_syntastic_css_mixedindentlint_checker = 1
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'css',
+    \ 'name': 'mixedindentlint',
+    \ 'redirect': 'javascript/mixedindentlint'})
+
+" vim: set et sts=4 sw=4:

--- a/syntax_checkers/javascript/mixedindentlint.vim
+++ b/syntax_checkers/javascript/mixedindentlint.vim
@@ -14,23 +14,8 @@ if exists('g:loaded_syntastic_javascript_mixedindentlint_checker')
 endif
 let g:loaded_syntastic_javascript_mixedindentlint_checker = 1
 
-if !exists('g:syntastic_javascript_mixedindentlint_generic')
-    let g:syntastic_javascript_mixedindentlint_generic = 0
-endif
-
 let s:save_cpo = &cpo
 set cpo&vim
-
-function! SyntaxCheckers_javascript_mixedindentlint_IsAvailable() dict
-    if g:syntastic_javascript_mixedindentlint_generic
-        call self.log('generic mixedindentlint, exec =', self.getExec())
-    endif
-
-    if !executable(self.getExec())
-        return 0
-    endif
-    return g:syntastic_javascript_mixedindentlint_generic || syntastic#util#versionIsAtLeast(self.getVersion(), [1, 0, 0])
-endfunction
 
 function! SyntaxCheckers_javascript_mixedindentlint_GetLocList() dict
     let makeprg = self.makeprgBuild({})
@@ -40,7 +25,8 @@ function! SyntaxCheckers_javascript_mixedindentlint_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'defaults': { 'bufnr': bufnr(''), 'text': 'Indentation that differs from rest of file' } })
+        \ 'defaults': { 'bufnr': bufnr(''), 'text': 'Indentation differs from rest of file' },
+        \ 'returns': [0,1] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/syntax_checkers/javascript/mixedindentlint.vim
+++ b/syntax_checkers/javascript/mixedindentlint.vim
@@ -1,0 +1,53 @@
+"============================================================================
+"File:        mixedindentlint.vim
+"Description: Mixed indentation linter for vim
+"Maintainer:  Payton Swick <payton@foolord.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_javascript_mixedindentlint_checker')
+    finish
+endif
+let g:loaded_syntastic_javascript_mixedindentlint_checker = 1
+
+if !exists('g:syntastic_javascript_mixedindentlint_generic')
+    let g:syntastic_javascript_mixedindentlint_generic = 0
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_javascript_mixedindentlint_IsAvailable() dict
+    if g:syntastic_javascript_mixedindentlint_generic
+        call self.log('generic mixedindentlint, exec =', self.getExec())
+    endif
+
+    if !executable(self.getExec())
+        return 0
+    endif
+    return g:syntastic_javascript_mixedindentlint_generic || syntastic#util#versionIsAtLeast(self.getVersion(), [1, 0, 0])
+endfunction
+
+function! SyntaxCheckers_javascript_mixedindentlint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = 'Line %l in "%f" %.%#.'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': { 'bufnr': bufnr(''), 'text': 'Indentation that differs from rest of file' } })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'javascript',
+    \ 'name': 'mixedindentlint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/scss/mixedindentlint.vim
+++ b/syntax_checkers/scss/mixedindentlint.vim
@@ -1,0 +1,22 @@
+"============================================================================
+"File:        mixedindentlint.vim
+"Description: Mixed indentation linter for vim
+"Maintainer:  Payton Swick <payton@foolord.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_scss_mixedindentlint_checker')
+    finish
+endif
+let g:loaded_syntastic_scss_mixedindentlint_checker = 1
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'scss',
+    \ 'name': 'mixedindentlint',
+    \ 'redirect': 'javascript/mixedindentlint'})
+
+" vim: set et sts=4 sw=4:


### PR DESCRIPTION
`mixedindentlint` looks for lines that do not match the indentation style of the file: https://github.com/sirbrillig/mixedindentlint

ie: if most of the file uses tabs, but there are lines indented with spaces, this checker will report the lines indented with spaces as warnings.