### PR TITLE
added support for gb build and gb test

### DIFF
--- a/syntax_checkers/go/gb.vim
+++ b/syntax_checkers/go/gb.vim
@@ -1,0 +1,97 @@
+"============================================================================
+"File:        go.vim
+"Description: Check go syntax using 'gofmt -l' followed by 'go [build|test]'
+"Maintainer:  Victor Vrantchan <vrantchan@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+"
+" This syntax checker does not reformat your source code.
+" Use a BufWritePre autocommand to that end:
+"   autocmd FileType go autocmd BufWritePre <buffer> Fmt
+
+if exists('g:loaded_syntastic_go_gb_checker')
+    finish
+endif
+let g:loaded_syntastic_go_gb_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_go_gb_IsAvailable() dict
+    return executable(self.getExec()) && executable('gofmt')
+endfunction
+
+function! SyntaxCheckers_go_gb_GetLocList() dict
+
+    " Check with gofmt first, since `go build` and `go test` might not report
+    " syntax errors in the current file if another file with syntax error is
+    " compiled first.
+    let makeprg = self.makeprgBuild({
+        \ 'exe': 'gofmt',
+        \ 'args': '-l',
+        \ 'tail': '> ' . syntastic#util#DevNull() })
+
+    let errorformat =
+        \ '%f:%l:%c: %m,' .
+        \ '%-G%.%#'
+
+    let errors = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'type': 'e'} })
+    if !empty(errors)
+        return errors
+    endif
+
+    " Test files, i.e. files with a name ending in `_test.go`, are not
+    " compiled by `go build`, therefore `go test` must be called for those.
+    if match(expand('%', 1), '\m_test\.go$') == -1
+        let cmd = 'build'
+        let cleanup = 0
+    else
+        let cmd = 'test'
+        let cleanup = 1
+    endif
+    let makeprg = self.getExecEscaped() . ' ' . cmd
+
+    " The first pattern is for warnings from C compilers.
+    let errorformat =
+        \ '%W%f:%l: warning: %m,' .
+        \ '%E%f:%l:%c:%m,' .
+        \ '%E%f:%l:%m,' .
+        \ '%C%\s%\+%m,' .
+        \ '%+Ecan''t load package: %m,' .
+        \ '%+Einternal error: %m,' .
+        \ '%-G#%.%#'
+
+    " The go compiler needs to either be run with an import path as an
+    " argument or directly from the package directory. Since figuring out
+    " the proper import path is fickle, just cwd to the package.
+
+    let errors = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'cwd': expand('%:p:h', 1),
+        \ 'env': {'GOGC': 'off'},
+        \ 'defaults': {'type': 'e'} })
+
+    if cleanup
+        call delete(expand('%:p:h', 1) . syntastic#util#Slash() . expand('%:p:h:t', 1) . '.test')
+    endif
+
+    return errors
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'go',
+    \ 'name': 'gb'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/go/gb.vim
+++ b/syntax_checkers/go/gb.vim
@@ -1,6 +1,6 @@
 "============================================================================
-"File:        go.vim
-"Description: Check go syntax using 'gofmt -l' followed by 'go [build|test]'
+"File:        gb.vim
+"Description: Check go syntax using 'gofmt -l' followed by 'gb [build|test]'
 "Maintainer:  Victor Vrantchan <vrantchan@gmail.com>
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
@@ -49,7 +49,7 @@ function! SyntaxCheckers_go_gb_GetLocList() dict
     endif
 
     " Test files, i.e. files with a name ending in `_test.go`, are not
-    " compiled by `go build`, therefore `go test` must be called for those.
+    " compiled by `gb build`, therefore `gb test` must be called for those.
     if match(expand('%', 1), '\m_test\.go$') == -1
         let cmd = 'build'
         let cleanup = 0


### PR DESCRIPTION
gb is a popular build tool for Go that uses a project folder instead of the usual $GOPATH/src/github.com/user/packagename directory structure.
After enabling `let g:syntastic_go_checkers = ['go']` syntastic would report `package not found in path` errors for packages in the `gb` project folder. 

I copied the `go.vim` checker to gb.vim and changed the checker to work with the `gb build` command when `let g:syntastic_go_checkers = ['gb']` is enabled. 

I don't have enough experience with vimscript, but I tested these changes with both gb folder structure and regular Go projects in `$GOPATH`, and errors are now reported as expected. 
