### PR TITLE
Add --force-exclusion flag to rubocop call

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -26,7 +26,7 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--format emacs' })
+    let makeprg = self.makeprgBuild({ 'args_after': '--format emacs --force-exclusion' })
 
     let errorformat = '%f:%l:%c: %t: %m'
 


### PR DESCRIPTION
This fixes what I thought to be an [issue](https://github.com/bbatsov/rubocop/issues/2492#issuecomment-164375887) of Rubocop itself.

Summary: Rubocop allows to configure the behaviour of its checkers by a config file (`.rubocop.yml`). E.g. you can disable particular checkers for certain files or paths (this surprisingly worked already before my patch) or you can disable all checkers for certain files or paths which did not work without the `--force-exclusion` flag.