### PR TITLE
JSCS checker: Removing warning when receiving empty json response.

### DIFF
--- a/autoload/syntastic/preprocess.vim
+++ b/autoload/syntastic/preprocess.vim
@@ -176,8 +176,6 @@ function! syntastic#preprocess#jscs(errors) abort " {{{2
                 call syntastic#log#warn('checker javascript/jscs: unrecognized error format')
             endif
         endfor
-    else
-        call syntastic#log#warn('checker javascript/jscs: unrecognized error format')
     endif
     return out
 endfunction " }}}2


### PR DESCRIPTION
Removing the warning that is printed when an empty json response is received from jscs.