### PR TITLE
#1664 - D syntax checker import fails with DSFML Lib 

### DIFF
--- a/syntax_checkers/d/dmd.vim
+++ b/syntax_checkers/d/dmd.vim
@@ -39,6 +39,7 @@ function! SyntaxCheckers_d_dmd_GetLocList() dict
     if !exists('g:syntastic_d_include_dirs')
         let g:syntastic_d_include_dirs = filter(glob($HOME . '/.dub/packages/*', 1, 1), 'isdirectory(v:val)')
         call map(g:syntastic_d_include_dirs, 'isdirectory(v:val . "/source") ? v:val . "/source" : v:val')
+        call map(g:syntastic_d_include_dirs, 'isdirectory(v:val . "/src") ? v:val . "/src" : v:val')
         call add(g:syntastic_d_include_dirs, './source')
     endif
 


### PR DESCRIPTION
- Add `src` directory to `g:syntastic_d_include_dirs`.
- Fix for issue https://github.com/scrooloose/syntastic/issues/1664