### PR TITLE
Added a flag for javac_config_file to use git root to find the config…

### DIFF
--- a/syntax_checkers/java/javac.vim
+++ b/syntax_checkers/java/javac.vim
@@ -55,8 +55,16 @@ if !exists('g:syntastic_java_javac_config_file_enabled')
     let g:syntastic_java_javac_config_file_enabled = 0
 endif
 
+if !exists('g:syntastic_java_javac_config_file_use_git_root')
+    let g:syntastic_java_javac_config_file_use_git_root = 0
+endif
+
 if !exists('g:syntastic_java_javac_config_file')
-    let g:syntastic_java_javac_config_file = '.syntastic_javac_config'
+    if g:syntastic_java_javac_config_file_use_git_root
+        let g:syntastic_java_javac_config_file = system('echo -n `git rev-parse --show-toplevel`') . '/.syntastic_javac_config'
+    else
+        let g:syntastic_java_javac_config_file = '.syntastic_javac_config'
+    endif
 endif
 
 if !exists('g:syntastic_java_javac_custom_classpath_command')

--- a/syntax_checkers/typescript/tsc.vim
+++ b/syntax_checkers/typescript/tsc.vim
@@ -39,8 +39,13 @@ function! SyntaxCheckers_typescript_tsc_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_typescript_tsc_GetLocList() dict
+    let args = '--module commonjs'
+    let filename = expand('%:e')
+    if filename == 'tsx'
+        let args = args . ' --jsx react'
+    endif
     let makeprg = self.makeprgBuild({
-        \ 'args': '--module commonjs',
+        \ 'args': args,
         \ 'args_after': (s:tsc_new ? '--noEmit' : '--out ' . syntastic#util#DevNull()) })
 
     let errorformat =


### PR DESCRIPTION
Having to open vim from the root of the git repo in order to get the functionality of .syntastic_javac_config is pretty annoying, so I added a flag to have syntastic check to see if the file exists at the root of the git repo regardless of where you open vim.