### PR TITLE
Add YAML checker: yamllint

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -100,7 +100,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'xslt':          ['xmllint'],
         \ 'xquery':        ['basex'],
         \ 'yacc':          ['bison'],
-        \ 'yaml':          ['jsyaml'],
+        \ 'yaml':          ['jsyaml', 'yamllint'],
         \ 'z80':           ['z80syntaxchecker'],
         \ 'zpt':           ['zptlint'],
         \ 'zsh':           ['zsh'],

--- a/syntax_checkers/yaml/yamllint.vim
+++ b/syntax_checkers/yaml/yamllint.vim
@@ -1,0 +1,34 @@
+"============================================================================
+"File:        yamllint.vim
+"Description: YAML files linting for syntastic.vim
+"Maintainer:  Adrien Vergé <http://yamllint.readthedocs.org/>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_yaml_yamllint_checker')
+    finish
+endif
+let g:loaded_syntastic_yaml_yamllint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_yaml_yamllint_GetLocList() dict
+    return SyntasticMake({
+        \ 'makeprg': self.makeprgBuild({ 'args_before': '-f parsable' }),
+        \ 'errorformat': '%E%f:%l:%c: [error] %m,%W%f:%l:%c: [warning] %m' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'yaml',
+    \ 'name': 'yamllint' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
yamllint [1] is a linter for YAML files. It does not only check for
syntax validity, but for common cosmetic conventions such as lines
length, trailing spaces, indentation, etc.

Also set yamllint as the default YAML linter, since other checkers
(js-yaml and yamlxs) do not do linting but solely detect syntax errors.

1: [http://yamllint.readthedocs.org/](http://yamllint.readthedocs.org/)