### PR TITLE
Linux makefile syntax checker with fixed arguments

### DIFF
--- a/syntax_checkers/c/makekernel.vim
+++ b/syntax_checkers/c/makekernel.vim
@@ -1,0 +1,64 @@
+"============================================================================
+"File:        makekernel.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Crt Mori <crt at the-mori dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_c_makekernel_checker')
+    finish
+endif
+let g:loaded_syntastic_c_makekernel_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_makekernel_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args-before': '', 'args': '-j4', 'fname': 'ARCH=arm CROSS_COMPILE=arm-none-eabi- am335x_boneblack42_defconfig zImage dtbs' })
+"    let makeprg = self.makeprgBuild({ 'args-before': '', 'args': '-j3', 'fname': 'ARCH=x86 x86_64_defconfig bzImage' })
+
+    let errorformat =
+        \ '%-G%f:%s:,' .
+        \ '%-G%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .
+        \ '%-G%f:%l: %#error: %#for each function it appears%.%#,' .
+        \ '%-GIn file included%.%#,' .
+        \ '%-G %#from %f:%l\,,' .
+        \ '%f:%l:%c: %trror: %m,' .
+        \ '%f:%l:%c: %tarning: %m,' .
+        \ '%f:%l:%c: %m,' .
+        \ '%f:%l: %trror: %m,' .
+        \ '%f:%l: %tarning: %m,'.
+        \ '%f:%l: %m'
+
+    if exists('g:syntastic_c_errorformat')
+        let errorformat = g:syntastic_c_errorformat
+    endif
+
+    " process makeprg
+    let errors = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat, 
+    	\ 'cwd': '~/kernel/' })
+
+    " filter the processed errors if desired
+    if exists('g:syntastic_c_remove_include_errors') && g:syntastic_c_remove_include_errors != 0
+        return filter(errors, 'has_key(v:val, "bufnr") && v:val["bufnr"] == ' . bufnr(''))
+    else
+        return errors
+    endif
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'makekernel',
+    \ 'exec': 'make' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
I saw the Issue scrooloose/syntastic#1383 and decided that it might be
useful to contribute my simple makefile for linux kernel development.

Changing a comment allows me to change the arguments passed to the Linux
Kernel makefile, path in cwd allows me to switch between different
forks. All the rest was copied from standard makefile syntax and
displays errors and warnings nicely.