### PR TITLE
add markdownlint checker

### DIFF
--- a/syntax_checkers/markdown/markdownlint.vim
+++ b/syntax_checkers/markdown/markdownlint.vim
@@ -1,0 +1,42 @@
+"============================================================================
+"File:        markdownlint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  David O'Trakoun <me at davidosomething dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_markdown_markdownlint_checker')
+    finish
+endif
+let g:loaded_syntastic_markdown_markdownlint_checker = 1
+
+if !exists('g:syntastic_markdown_markdownlint_sort')
+    let g:syntastic_markdown_markdownlint_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_markdown_markdownlint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+    let errorformat = '%E%f: %l: %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'markdown',
+    \ 'name': 'markdownlint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
requires https://github.com/igorshubovych/markdownlint-cli npm package

configurable using a json file:

      let b:syntastic_markdown_markdownlint_args = '--config markdownlint.json'

different from mdl in that it runs using node and has more configuration options for rules (but otherwise same rules). Also the errorfmt is different by one space.