### PR TITLE
Remove erroneous line from FAQ

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -280,7 +280,6 @@ install this plugin the checker should be picked up automatically by syntastic.
 
 <a name="faqloclist"></a>
 
-__4.7. Q. I run a checker and the location list is not updated...__  
 __4.7. Q. I run`:lopen` or `:lwindow` and the error window is empty...__
 
 A. By default the location list is changed only when you run the `:Errors`


### PR DESCRIPTION
The line in question "__4.7. Q. I run a checker and the location list is not updated...__" preceded a question that was almost, but more detailed, with the same number as it.