### PR TITLE
Checker rst/rst2pseudoxml: errors without a line #

### DIFF
--- a/syntax_checkers/rst/rst2pseudoxml.vim
+++ b/syntax_checkers/rst/rst2pseudoxml.vim
@@ -31,7 +31,12 @@ function! SyntaxCheckers_rst_rst2pseudoxml_GetLocList() dict
     let errorformat =
         \ '%f:%l: (%tNFO/1) %m,'.
         \ '%f:%l: (%tARNING/2) %m,'.
-        \ '%f:%l: (%tRROR/3) %m,'.
+        \ '%f:%l: (%tRROR/3) %m,'
+    " Match errors like 'Anonymous hyperlink mismatch' that don't have line
+    " numbers
+    let errorformat .= '%f:: (%tRROR/3) %m,'
+    let errorformat .=
+        \ '%f:%l: (%tNFO/1) %m,'.
         \ '%f:%l: (%tEVERE/4) %m,'.
         \ '%-G%.%#'
 


### PR DESCRIPTION
Stop a type of error failing silently; for example if a document
includes:

    `Link text`__

but misses the corresponding:

    .. __: http://www.example.org

then without this patch, syntastic shows no errors. `rst2pseudoxml`
produces output like:

    file.txt:2: (ERROR/3) Anonymous hyperlink mismatch: 1 references but 0 targets.
    See "backrefs" attribute for IDs.

This patch adds a pattern to 'errorformat' to catch this type of error
message that doesn't include a line number.