### PR TITLE
hdevtools: Preserve multi-line comments

### DIFF
--- a/autoload/syntastic/postprocess.vim
+++ b/autoload/syntastic/postprocess.vim
@@ -21,6 +21,27 @@ function! syntastic#postprocess#compressWhitespace(errors) abort " {{{2
     return a:errors
 endfunction " }}}2
 
+" remove initial empty lines
+function! syntastic#postprocess#removeEmptyLines(errors) abort " {{{2
+    for e in a:errors
+        let e['text'] = substitute(e['text'], '\m^\n\+', '', '')
+    endfor
+
+    return a:errors
+endfunction " }}}2
+
+" unindent consistently
+function! syntastic#postprocess#unindent(errors) abort " {{{2
+    for e in a:errors
+        let lines = split(e['text'], '\n', 1)
+        let indent = min(map(copy(lines), 'len(matchstr(v:val,"^ \\+"))'))
+        let lines = map(lines, 'v:val[' . indent . ':]')
+        let e['text'] = join(lines, "\n")
+    endfor
+
+    return a:errors
+endfunction " }}}2
+
 " remove spurious CR under Cygwin
 function! syntastic#postprocess#cygwinRemoveCR(errors) abort " {{{2
     if has('win32unix')

--- a/syntax_checkers/haskell/hdevtools.vim
+++ b/syntax_checkers/haskell/hdevtools.vim
@@ -43,7 +43,7 @@ function! SyntaxCheckers_haskell_hdevtools_GetLocList() dict
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'vcol': 1},
-        \ 'postprocess': ['compressWhitespace'] })
+        \ 'postprocess': ['removeEmptyLines', 'unindent'] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
but trim unnecessary line white space above (empty lines) and left
(commont indentation). This fixes #1700.

Note that this is my first adventure into vimscript, so I might have messed up in one way or the other.