### PR TITLE
Support for the renaming of Jade to Pug

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,7 @@ Ada, Ansible configurations, API Blueprint, AppleScript, AsciiDoc, ASM,
 BEMHTML, Bro, Bourne shell, C, C++, C#, Cabal, Chef, CoffeeScript, Coco, Coq,
 CSS, Cucumber, CUDA, D, Dart, DocBook, Dockerfile, Dust, Elixir, Erlang,
 eRuby, Fortran, Gentoo metadata, GLSL, Go, Haml, Haskell, Haxe, Handlebars,
-HSS, HTML, Jade, Java, JavaScript, JSON, JSX, LESS, Lex, Limbo, LISP, LLVM
+HSS, HTML, Jade/Pug, Java, JavaScript, JSON, JSX, LESS, Lex, Limbo, LISP, LLVM
 intermediate language, Lua, Markdown, MATLAB, Mercury, NASM, Nix, Objective-C,
 Objective-C++, OCaml, Perl, Perl POD, PHP, gettext Portable Object, OS X and
 iOS property lists, Puppet, Python, QML, R, Racket, Relax NG, reStructuredText,

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -45,6 +45,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'hss':           ['hss'],
         \ 'html':          ['tidy'],
         \ 'jade':          ['jade_lint'],
+        \ 'pug':          ['pug_lint'],
         \ 'java':          ['javac'],
         \ 'javascript':    ['jshint', 'jslint'],
         \ 'json':          ['jsonlint', 'jsonval'],

--- a/syntax_checkers/pug/pug_lint.vim
+++ b/syntax_checkers/pug/pug_lint.vim
@@ -1,0 +1,41 @@
+"============================================================================
+"File:        pug_lint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Kevin Olson <acidjazz@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://www.wtfpl.net/txt/copying/ for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_pug_pug_lint_checker')
+    finish
+endif
+let g:loaded_syntastic_pug_pug_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_pug_pug_lint_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args_after': '-r inline' })
+
+    let errorformat = '%f:%l:%c %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 2] })
+endfunction
+
+" need to eventually change for when jade-lint is renamed
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'pug',
+    \ 'name': 'pug_lint',
+    \ 'exec': 'jade-lint' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Due to this [unfortunate incident](https://github.com/pugjs/jade/issues/2184), [these fine people](https://www.jadeworld.com/) have trademarked a [rock](https://en.wikipedia.org/wiki/Jade). Forcing the rename of the Jade language to [Pug](https://github.com/pugjs), which I think is a compliment to the company that trademarks minerals since the CIO [resembles the breed](https://www.jadeworld.com/media-center/cio-john-ascroft-traditional-businesses-going-digital/)