### PR TITLE
NASM syntax-checker : -f elf to args_after to be able to override them

### DIFF
--- a/syntax_checkers/nasm/nasm.vim
+++ b/syntax_checkers/nasm/nasm.vim
@@ -20,8 +20,8 @@ set cpo&vim
 
 function! SyntaxCheckers_nasm_nasm_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \	'args_before': ' -f elf' ,
-        \ 	'args_after': ' -X gnu' .
+        \ 	'args_after': ' -X gnu' ,
+        \	'post_args': ' -f elf' .
         \       ' -I ' . syntastic#util#shescape(expand('%:p:h', 1) . syntastic#util#Slash()) .
         \       ' ' . syntastic#c#NullOutput() })
 

--- a/syntax_checkers/nasm/nasm.vim
+++ b/syntax_checkers/nasm/nasm.vim
@@ -20,7 +20,8 @@ set cpo&vim
 
 function! SyntaxCheckers_nasm_nasm_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '-X gnu -f elf' .
+        \	'args_before': ' -f elf' ,
+        \ 	'args_after': ' -X gnu' .
         \       ' -I ' . syntastic#util#shescape(expand('%:p:h', 1) . syntastic#util#Slash()) .
         \       ' ' . syntastic#c#NullOutput() })
 


### PR DESCRIPTION
This allows to override the ```-f``` option in ```.vimrc```.
For example : ```let g:syntastic_nasm_nasm_args = "-f elf64"```