### PR TITLE
Support new HLint version

### DIFF
--- a/syntax_checkers/haskell/hlint.vim
+++ b/syntax_checkers/haskell/hlint.vim
@@ -21,6 +21,7 @@ function! SyntaxCheckers_haskell_hlint_GetLocList() dict
         \ '%E%f:%l:%v: Error while reading hint file\, %m,' .
         \ '%E%f:%l:%v: Error: %m,' .
         \ '%W%f:%l:%v: Warning: %m,' .
+        \ '%W%f:%l:%v: Suggestion: %m,' .
         \ '%C%m'
 
     return SyntasticMake({


### PR DESCRIPTION
In the [latest version of HLint](http://neilmitchell.blogspot.com/2016/02/new-hlint-version-and-api-features.html), linting warnings are now classified as "Suggestion".

Tested with Stack on a file with a handful of warnings and suggestions.  This could be the underlying cause of #1688, which was posted a few days after the new HLint was released (though only if the user had a cabal or stack installed version ahead of the dpkg version in his PATH).