### PR TITLE
Update to match latest version of js-yaml

### DIFF
--- a/syntax_checkers/yaml/jsyaml.vim
+++ b/syntax_checkers/yaml/jsyaml.vim
@@ -19,15 +19,10 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_yaml_jsyaml_GetLocList() dict
-    if !exists('s:js_yaml_new')
-        let s:js_yaml_new = syntastic#util#versionIsAtLeast(self.getVersion(), [2])
-    endif
 
-    let makeprg = self.makeprgBuild({ 'args_after': (s:js_yaml_new ? '' : '--compact') })
+    let makeprg = self.makeprgBuild({})
 
     let errorformat =
-        \ 'Error on line %l\, col %c:%m,' .
-        \ 'JS-YAML: %m at line %l\, column %c:,' .
         \ 'YAMLException: %m at line %l\, column %c:,' .
         \ '%-G%.%#'
 


### PR DESCRIPTION
Apparently a few things have changed with the latest version and he `compact` flag no longer outputs line and column numbers.
I have removed the additional flag and adjusted the error message prefix to match with https://github.com/nodeca/js-yaml (3.5.3).
Hopefully that  can be helpful.