### PR TITLE
Pass --dev flag to jruby for faster startup

### DIFF
--- a/syntax_checkers/ruby/jruby.vim
+++ b/syntax_checkers/ruby/jruby.vim
@@ -21,7 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_ruby_jruby_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'args': (syntastic#util#isRunningWindows() ? '-T1 -W1' : '-W1'),
-        \ 'args_after': '-c' })
+        \ 'args_after': '--dev -c' })
 
     let errorformat =
         \ '%-GSyntax OK for %f,'.


### PR DESCRIPTION
Pass the `--dev` flag to jruby to (slightly) improve startup time, as documented here: https://github.com/jruby/jruby/wiki/Improving-startup-time

Caveats: this only works with newer versions of jruby, not sure what the best way to do a version check is.