### PR TITLE
Change scss-lint executable to scss_lint

### DIFF
--- a/syntax_checkers/scss/scss_lint.vim
+++ b/syntax_checkers/scss/scss_lint.vim
@@ -56,7 +56,7 @@ endfunction
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'scss',
     \ 'name': 'scss_lint',
-    \ 'exec': 'scss-lint' })
+    \ 'exec': 'scss_lint' })
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
see https://github.com/brigade/scss-lint/commit/c1e311b495cfd189f63aa8cc821ca036b47a9fe9 - this is now the proper executable per Gem name standards