### PR TITLE
D checker: Add src to default source paths

### DIFF
--- a/syntax_checkers/d/dmd.vim
+++ b/syntax_checkers/d/dmd.vim
@@ -39,7 +39,9 @@ function! SyntaxCheckers_d_dmd_GetLocList() dict
     if !exists('g:syntastic_d_include_dirs')
         let g:syntastic_d_include_dirs = filter(glob($HOME . '/.dub/packages/*', 1, 1), 'isdirectory(v:val)')
         call map(g:syntastic_d_include_dirs, 'isdirectory(v:val . "/source") ? v:val . "/source" : v:val')
+        call map(g:syntastic_d_include_dirs, 'isdirectory(v:val . "/src") ? v:val . "/src" : v:val')
         call add(g:syntastic_d_include_dirs, './source')
+        call add(g:syntastic_d_include_dirs, './src')
     endif
 
     return syntastic#c#GetLocList('d', 'dmd', {


### PR DESCRIPTION
src and source are both default source paths in DUB.