### PR TITLE
Fix grammatical error in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -190,7 +190,7 @@ let g:syntastic_check_on_wq = 0
 __4.1. Q. I installed syntastic but it isn't reporting any errors...__
 
 A. The most likely reason is that none of the syntax checkers that it requires
-is installed. For example: by default, python requires either `flake8` or
+are installed. For example: by default, python requires either `flake8` or
 `pylint` to be installed and in your `$PATH`. To see which executables are
 supported, look at the [wiki][3]. Note that aliases do not work; the actual
 executables must be available in your `$PATH`. Symbolic links are okay though.


### PR DESCRIPTION
Fix grammatical error: "none ... is" => "none ... are"