### PR TITLE
Absolute filepath for error and warnings.

### DIFF
--- a/syntax_checkers/ada/gcc.vim
+++ b/syntax_checkers/ada/gcc.vim
@@ -32,8 +32,8 @@ function! SyntaxCheckers_ada_gcc_GetLocList() dict
         \     '%-G%f:%s:,' .
         \     '%f:%l:%c: %m,' .
         \     '%f:%l: %m',
-        \ 'main_flags': '-c -x ada -gnats',
-        \ 'header_flags': '-x ada -gnats',
+        \ 'main_flags': '-c -x ada -gnats -gnatef',
+        \ 'header_flags': '-x ada -gnats -gnatef',
         \ 'header_names': '\.ads$' })
 endfunction
 


### PR DESCRIPTION
On save file, if the file is in project, open new buffer with bad filepath so the buffer open is empty.
Before change:
```shell
gcc -c -x ada -gnats src/principale.adb
principale.adb:32:26: missing ";"
```

quickfix try to open principale.adb but file is in src/ not in current directory.

After change:
```shell
gcc -c -x ada -gnats -gnatef src/principale.adb 
src/principale.adb:32:26: missing ";"
```

quickfix open file src/principale.adb.