### PR TITLE
checker govet: use makeprgBuild

### DIFF
--- a/syntax_checkers/go/govet.vim
+++ b/syntax_checkers/go/govet.vim
@@ -23,7 +23,7 @@ function! SyntaxCheckers_go_govet_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_go_govet_GetLocList() dict
-    let makeprg = self.getExecEscaped() . ' vet'
+    let makeprg = self.makeprgBuild({ 'args_before': 'vet' })
 
     let errorformat =
         \ '%Evet: %.%\+: %f:%l:%c: %m,' .


### PR DESCRIPTION
The current [wiki page][1] states that the govet checker doesn't use the
makeprgBuild function. I couldn't find a documented reason (in wiki,
commit messages, or in #616) that indicates why it must not use
makeprgBuild, so this commit makes it so. It's probably because the
checker was added in April 2013, before makeprgBuild was added in
November 2013.

The specific reason this is desirable is that otherwise `go vet` is
invoked without any extra arguments, meaning that it runs on the entire
set of files in the current directory. This causes it to output warnings
for files that are not the current file; the current file may be clean
but I may still see warnings for other files.

By using makeprgBuild, in addition to respecting
`g:syntastic_go_govet_<option>`, it would also only run on the current
file.

[1]: https://github.com/scrooloose/syntastic/wiki/Go:---govet