### PR TITLE
Choose dialect based on vim syntax

### DIFF
--- a/syntax_checkers/sh/shellcheck.vim
+++ b/syntax_checkers/sh/shellcheck.vim
@@ -11,8 +11,21 @@ let g:loaded_syntastic_sh_shellcheck_checker = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:GetDialectArgument()
+    if exists('b:is_bash') && b:is_bash
+        return '-s bash'
+    elseif exists('b:is_sh') && b:is_sh
+        return '-s sh'
+    elseif exists('b:is_kornshell') && b:is_kornshell
+        return '-s ksh'
+    endif
+
+    return ''
+endfunction
+
 function! SyntaxCheckers_sh_shellcheck_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '-f gcc' })
+    let args = '-f gcc ' . s:GetDialectArgument()
+    let makeprg = self.makeprgBuild({ 'args_after': args })
 
     let errorformat =
         \ '%f:%l:%c: %trror: %m,' .


### PR DESCRIPTION
Shellcheck is smart enough to check the shebang in a given file to
determine which dialect to use. Unfortunately this doesn't work for
files without shebangs, even if it might be apparent what dialect should
be used, such as "bashrc" or "foo.bash". Luckily `filetype.vim` defines
specific vars based on which shell dialect is being used based on a huge
list of conditions. With this change we take those into account for all
the types shellcheck supports, otherwise we fallback to letting it try
and decide.