### PR TITLE
Enable the ttl checker by default

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -91,7 +91,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'texinfo':       ['makeinfo'],
         \ 'text':          [],
         \ 'trig':          ['rapper'],
-        \ 'turtle':        ['rapper'],
+        \ 'turtle':        ['rapper', "ttl"],
         \ 'twig':          ['twiglint'],
         \ 'typescript':    ['tsc'],
         \ 'vala':          ['valac'],

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -91,7 +91,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'texinfo':       ['makeinfo'],
         \ 'text':          [],
         \ 'trig':          ['rapper'],
-        \ 'turtle':        ['rapper', "ttl"],
+        \ 'turtle':        ['rapper', 'ttl'],
         \ 'twig':          ['twiglint'],
         \ 'typescript':    ['tsc'],
         \ 'vala':          ['valac'],


### PR DESCRIPTION
It would be nice to have the ttl checker enabled by default, if available.