### PR TITLE
Adds scss load-path for Rails projects

### DIFF
--- a/syntax_checkers/sass/sass.vim
+++ b/syntax_checkers/sass/sass.vim
@@ -44,7 +44,7 @@ function! SyntaxCheckers_sass_sass_GetLocList() dict
     endif
 
     let makeprg = self.makeprgBuild({
-        \ 'args_before': '--cache-location ' . s:sass_cache_location . ' ' . s:imports . ' --check' })
+        \ 'args_before': '-I app/assets/stylesheets --cache-location ' . s:sass_cache_location . ' ' . s:imports . ' --check' })
 
     let errorformat =
         \ '%E%\m%\%%(Syntax %\)%\?%trror: %m,' .


### PR DESCRIPTION
I want to start a discussion around this.  When working on a Rails project, you will get a lot of 'could not find import' errors because the stylesheet asset path in Rails is app/assets/stylesheets - Is there already a way, or can we create a way to specify these paths?