### PR TITLE
Allow numbers in environment variables

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -522,7 +522,7 @@ function! SyntasticMake(options) abort " {{{2
     let env_save = {}
     if has_key(a:options, 'env') && len(a:options['env'])
         for key in keys(a:options['env'])
-            if key =~? '\m^[a-z_]\+$'
+            if key =~? '\m^[a-z0-9_]\+$'
                 execute 'let env_save[' . string(key) . '] = $' . key
                 execute 'let $' . key . ' = ' . string(a:options['env'][key])
             endif


### PR DESCRIPTION
Before this change, if you tried to set an environment variable where
the key contained a number, it would be ignored. This means if you tried
to set something such as `SCRIPT_INPUT_FILE_0`, this wouldn't work as
expected. (This example is commonly used by iOS build tools [see here](http://indiestack.com/2014/12/speeding-up-custom-script-phases/))

To reproduce this issue you can call `SyntasticMake` passing `{ 'SCRIPT_INPUT_FILE_0': 1 }` for the `env` key.

I couldn't find any background on why this regex didn't previously allow numbers so if that was intentional I can update this as necessary!