### PR TITLE
Fix ansible-lint errorformat

### DIFF
--- a/syntax_checkers/ansible/ansible_lint.vim
+++ b/syntax_checkers/ansible/ansible_lint.vim
@@ -28,7 +28,7 @@ endfunction
 function! SyntaxCheckers_ansible_ansible_lint_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '-p' })
 
-    let errorformat = '%f:%l: [ANSIBLE%n] %m'
+    let errorformat = '%f:%l: [EANSIBLE%n] %m'
 
     let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb' }
 


### PR DESCRIPTION
See commit https://github.com/willthames/ansible-lint/commit/52a9e0b5f3f0df4d2a9a092ecf6935def7a3e5cf: an `E` has been added to the ansible-lint output string.