### PR TITLE
Checker nvcc: use makeprgBuild and add config file support

### DIFF
--- a/syntax_checkers/cuda/nvcc.vim
+++ b/syntax_checkers/cuda/nvcc.vim
@@ -22,13 +22,14 @@ function! SyntaxCheckers_cuda_nvcc_GetLocList() dict
         \ 'args_before': '--cuda -O0 -I . ' .
         \ syntastic#c#ReadConfig(g:syntastic_cuda_config_file) .
         \ ' -Xcompiler -fsyntax-only',
-        \ 'tail_after': syntastic#c#NullOutput()}
+        \ 'tail': syntastic#c#NullOutput()}
 
     if index(['h', 'hpp', 'cuh'], expand('%:e', 1), 0, 1) >= 0
         if syntastic#util#var('cuda_check_header', 0)
-            let buildoptions.exe_before = 'touch /tmp/.syntastic_dummy.cu ;'
-            let buildoptions.fname = '/tmp/.syntastic_dummy.cu'
+            let buildoptions.exe_before = 'echo > .syntastic_dummy.cu ;'
+            let buildoptions.fname = '.syntastic_dummy.cu'
             let buildoptions.args_after = '-include ' . syntastic#util#shexpand('%')
+            let buildoptions.tail_after = '; rm .syntastic_dummy.cu'
         else
             return []
         endif

--- a/syntax_checkers/cuda/nvcc.vim
+++ b/syntax_checkers/cuda/nvcc.vim
@@ -10,12 +10,18 @@ if exists('g:loaded_syntastic_cuda_nvcc_checker')
 endif
 let g:loaded_syntastic_cuda_nvcc_checker = 1
 
+if !exists('g:syntastic_cuda_config_file')
+    let g:syntastic_cuda_config_file = '.syntastic_cuda_config'
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_cuda_nvcc_GetLocList() dict
     let buildoptions = {
-        \ 'args_before': '--cuda -O0 -I . -Xcompiler -fsyntax-only',
+        \ 'args_before': '--cuda -O0 -I . ' .
+        \ syntastic#c#ReadConfig(g:syntastic_cuda_config_file) .
+        \ ' -Xcompiler -fsyntax-only',
         \ 'tail_after': syntastic#c#NullOutput()}
 
     if index(['h', 'hpp', 'cuh'], expand('%:e', 1), 0, 1) >= 0


### PR DESCRIPTION
The nvcc checker is currently not using the makeprgBuild function and thus does not allow users to set compiler arguments within vim configs. There is also no support for config files.
This pull request adds support for both.

I am not an experienced vimscript user and help as well as a code review would be most welcome, although most of this is copied from other checkers...