### PR TITLE
Add new C checker: ninja

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -867,6 +867,22 @@ File containing project-specific options to be passed to "Splint"
 (such as defines or include directories), one option per line (cf.
 |syntastic-config-files|).
 
+------------------------------------------------------------------------------
+12. Ninja                                                  *syntastic-c-ninja*
+
+Name:        ninja
+Maintainer:  Rabin Vincent <rabin@rab.in>
+
+"Ninja" is a small build system with a focus on speed. See the project's page
+for details:
+
+    https://ninja-build.org/
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
 ==============================================================================
 SYNTAX CHECKERS FOR C#                                 *syntastic-checkers-cs*
 

--- a/syntax_checkers/c/ninja.vim
+++ b/syntax_checkers/c/ninja.vim
@@ -1,0 +1,61 @@
+"============================================================================
+"File:        ninja.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Rabin Vincent <rabin at rab dot in>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_c_ninja_checker')
+    finish
+endif
+let g:loaded_syntastic_c_ninja_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_ninja_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'fname': syntastic#util#shexpand('%') . '^' })
+
+    let errorformat =
+        \ '%-G%f:%s:,' .
+        \ '%-G%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .
+        \ '%-G%f:%l: %#error: %#for each function it appears%.%#,' .
+        \ '%-GIn file included%.%#,' .
+        \ '%-G %#from %f:%l\,,' .
+        \ '%f:%l:%c: %trror: %m,' .
+        \ '%f:%l:%c: %tarning: %m,' .
+        \ '%f:%l:%c: %m,' .
+        \ '%f:%l: %trror: %m,' .
+        \ '%f:%l: %tarning: %m,'.
+        \ '%f:%l: %m'
+
+    if exists('g:syntastic_c_errorformat')
+        let errorformat = g:syntastic_c_errorformat
+    endif
+
+    " process makeprg
+    let errors = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+
+    " filter the processed errors if desired
+    if exists('g:syntastic_c_remove_include_errors') && g:syntastic_c_remove_include_errors != 0
+        return filter(errors, 'has_key(v:val, "bufnr") && v:val["bufnr"] == ' . bufnr(''))
+    else
+        return errors
+    endif
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'ninja'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Add a new C checker for the Ninja build system.  Currently, the only
difference between this and the make checker, apart from the name,  is
the fname, which uses Ninja's file^ syntax to build the first output for
the given source file.