### PR TITLE
Support b:syntastic_filetype_map and b:syntastic_*_checkers

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -632,7 +632,12 @@ endfunction " }}}2
 
 function! s:_resolve_filetypes(filetypes) abort " {{{2
     let type = len(a:filetypes) ? a:filetypes[0] : &filetype
-    return split( get(g:syntastic_filetype_map, type, type), '\m\.' )
+    if exists('b:syntastic_filetype_map') && has_key(b:syntastic_filetype_map, type)
+        let type = get(b:syntastic_filetype_map, type)
+    else
+        let type = get(g:syntastic_filetype_map, type, type)
+    endif
+    return split(type, '\m\.')
 endfunction " }}}2
 
 function! s:_ignore_file(filename) abort " {{{2

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -199,6 +199,7 @@ function! g:SyntasticRegistry.getCheckers(ftalias, hints_list) abort " {{{2
     let names =
         \ !empty(a:hints_list) ? syntastic#util#unique(a:hints_list) :
         \ exists('b:syntastic_checkers') ? b:syntastic_checkers :
+        \ exists('b:syntastic_' . ft . '_checkers') ? b:syntastic_{ft}_checkers :
         \ exists('g:syntastic_' . ft . '_checkers') ? g:syntastic_{ft}_checkers :
         \ get(s:_DEFAULT_CHECKERS, ft, 0)
 
@@ -229,6 +230,10 @@ function! g:SyntasticRegistry.getKnownFiletypes() abort " {{{2
 
     if exists('g:syntastic_extra_filetypes') && type(g:syntastic_extra_filetypes) == type([])
         call extend(types, g:syntastic_extra_filetypes)
+    endif
+
+    if exists('b:syntastic_filetype_map')
+        call extend(types, keys(b:syntastic_filetype_map))
     endif
 
     return syntastic#util#unique(types)


### PR DESCRIPTION
This allows linters to be overridden in autocmd via buffer-local variables.

Buffer-local linting was already introduced in #532, but that only added support for flipping the linter setting for *all* types. This PR allows linting to be configured more granularly, per language and even with file type mappings. Here is an example of how these buffer variables can be used: https://wiki.mozilla.org/index.php?title=WebExtensions/Hacking&oldid=1138155#Vim