### PR TITLE
New checker for Markdown: alex

### DIFF
--- a/autoload/syntastic/preprocess.vim
+++ b/autoload/syntastic/preprocess.vim
@@ -8,6 +8,34 @@ set cpo&vim
 
 " Public functions {{{1
 
+function! syntastic#preprocess#alex(errors) abort " {{{2
+    let out = []
+    for err in a:errors
+      let split = split(err, '\s\+')
+
+      " Skipping header/footers
+      if len(split) < 4
+        continue
+      endif
+
+      let type = split[1]
+      if type ==# 'warning'
+        let type = 'W'
+      else
+        let type = 'E'
+      endif
+
+      let line = split(split[0],':')[0]
+
+      let rulename = split[-1]
+      let description = join(split[2:-2], ' ')
+      let message = '[' . rulename . '] ' . description
+
+      call add(out, type . ':' . line . ':' . message)
+    endfor
+    return out
+endfunction " }}}2
+
 function! syntastic#preprocess#cabal(errors) abort " {{{2
     let out = []
     let star = 0

--- a/syntax_checkers/markdown/alex.vim
+++ b/syntax_checkers/markdown/alex.vim
@@ -1,0 +1,45 @@
+"============================================================================
+"File:        alex.vim
+"Description: Insensitive, inconsiderate writing checking plugin for 
+"             syntastic.vim using `alex` (https://github.com/wooorm/alex).
+"Maintainer:  Tim Carry <tim at pixelastic dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_markdown_alex_checker')
+    finish
+endif
+let g:loaded_syntastic_markdown_alex_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_markdown_alex_GetLocList() dict
+    " printm "test"
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%t:%l:%m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')},
+        \ 'subtype': 'Style',
+        \ 'preprocess': 'alex'})
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'markdown',
+    \ 'name': 'alex'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:
+
+


### PR DESCRIPTION
This adds a text checker to markdown files using the [alexjs](http://alexjs.com/) linter. As they put on their website, Alex checks for `gender favouring, polarising, race related, religion inconsiderate, or other unequal phrasing.` Like warning of the use of `his`/`her` instead of `their`.

The linter expect the `alex` command to be available (`npm install -g alex`).

The tool seems quite young and might require a bit of configuration to avoid false positives, but this is out of the scope of this plugin. From my limited testing it seems to only output warnings, I did not manage to make it output errors (still, the code should handle just fine).

I used a `preprocess` for the parsing of the output, which is way easier than a pure `errorformat` but I'm pretty sure this can be handled by `errorformat` by anyone with better skills.