### PR TITLE
New checker for asl: iasl

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -6,6 +6,7 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
 
 |syntastic| comes with checkers for the following languages:
 
+    ACPI Source Language.....................|syntastic-checkers-asl|
     ActionScript.............................|syntastic-checkers-actionscript|
     Ada......................................|syntastic-checkers-ada|
     Ansible..................................|syntastic-checkers-ansible|
@@ -131,6 +132,39 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
     Zsh......................................|syntastic-checkers-zsh|
 
 Third-party checkers are available for additional languages.
+
+==============================================================================
+SYNTAX CHECKERS FOR ACPI SOURCE LANGUAGE              *syntastic-checkers-asl*
+
+The following checkers are available for the ACPI Source Language (filetype
+"asl"):
+
+    1. iasl.....................|syntastic-asl-iasl|
+
+------------------------------------------------------------------------------
+1. iasl                                                   *syntastic-asl-iasl*
+
+Name:        iasl
+Maintainer:  Peter Wu <peter@lekensteyn.nl>
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+Additionally:
+
+                                        *'g:syntastic_asl_iasl_delete_output'*
+Type: boolean
+Default: 1
+When set the checker will delete the ".aml" files created by "iasl".
+
+Note~
+
+You probably also need a plugin to set |filetype| for ASL files, such as
+"vim-acpi-asl":
+
+    https://github.com/martinlroth/vim-acpi-asl
 
 ==============================================================================
 SYNTAX CHECKERS FOR ACTIONSCRIPT             *syntastic-checkers-actionscript*

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -12,6 +12,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'apiblueprint':  ['drafter'],
         \ 'applescript':   ['osacompile'],
         \ 'asciidoc':      ['asciidoc'],
+        \ 'asl':           ['iasl'],
         \ 'asm':           ['gcc'],
         \ 'bro':           ['bro'],
         \ 'bemhtml':       ['bemhtmllint'],

--- a/syntax_checkers/asl/iasl.vim
+++ b/syntax_checkers/asl/iasl.vim
@@ -58,9 +58,9 @@ function! SyntaxCheckers_asl_iasl_GetLocList() dict " {{{1
         \ 'returns': [0, 255] })
 
     " Change Remark comments to Warnings. Optimization comments are normally not
-    " reported unless '-vo' is added to the iasl options (not a Warning!).
+    " reported unless '-vo' is added to the iasl options.
     for e in loclist
-        if e['type'] =~? 'r'
+        if e['type'] =~? 'r' || e['type'] =~? 'o'
             let e['type'] = 'W'
         endif
     endfor

--- a/syntax_checkers/asl/iasl.vim
+++ b/syntax_checkers/asl/iasl.vim
@@ -31,7 +31,7 @@ function! SyntaxCheckers_asl_iasl_GetLocList() dict " {{{1
 
     let output_dir = ''
     if g:syntastic_asl_iasl_delete_output
-        let output_dir = syntastic#util#tmpdir()
+        let output_dir = syntastic#util#tmpdir() . syntastic#util#Slash()
         let iasl_opts .= ' -p' . syntastic#util#shescape(output_dir)
     endif
 

--- a/syntax_checkers/asl/iasl.vim
+++ b/syntax_checkers/asl/iasl.vim
@@ -1,0 +1,88 @@
+"============================================================================
+"File:        iasl.vim
+"Description: Syntax checking plugin for syntastic.vim using iasl
+"Maintainer:  Peter Wu <peter@lekensteyn.nl>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_asl_iasl_checker')
+    finish
+endif
+let g:loaded_syntastic_asl_iasl_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+" Checker options {{{1
+
+if !exists('g:syntastic_asl_iasl_options')
+    let g:syntastic_asl_iasl_options = ''
+endif
+
+if !exists('g:syntastic_asl_iasl_delete_output')
+    let g:syntastic_asl_iasl_delete_output = 1
+endif
+
+" }}}1
+
+function! SyntaxCheckers_asl_iasl_GetLocList() dict " {{{1
+    " Enable less verbose messages for use with IDES (MSVC style).
+    let iasl_opts = '-vi'
+
+    let output_dir = ''
+    if g:syntastic_asl_iasl_delete_output
+        let output_dir = syntastic#util#tmpdir()
+        let iasl_opts .= ' -p' . syntastic#util#shescape(output_dir)
+    endif
+
+    let makeprg = self.makeprgBuild({
+        \ 'args': g:syntastic_asl_iasl_options,
+        \ 'args_after': iasl_opts })
+
+    " See source/compiler/aslmessages.c for functions that produce output:
+    " AePrintException, called via AslCommonError, via AslError.
+    " "%s(%u) : %s"             filename, line no, message without ID
+    " "%s(%u) : %s %4.4d - %s"  filename, line no, level, exception code, msg
+    let errorformat =
+        \ '%f(%l) : %trror    %n - %m,' .
+        \ '%f(%l) : %tarning  %n - %m,' .
+        \ '%f(%l) : %temark   %n - %m,' .
+        \ '%f(%l) : %tptimize %n - %m,' .
+        \ '%f(%l) : %m'
+
+    if output_dir !=# ''
+        silent! call mkdir(output_dir, 'p')
+    endif
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 255] })
+
+    " Change Remark comments to Warnings. Optimization comments are normally not
+    " reported unless '-vo' is added to the iasl options (not a Warning!).
+    for e in loclist
+        if e['type'] =~? 'r'
+            let e['type'] = 'W'
+        endif
+    endfor
+
+    if output_dir !=# ''
+        call syntastic#util#rmrf(output_dir)
+    endif
+
+    return loclist
+endfunction "}}}1
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'asl',
+    \ 'name': 'iasl'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/asl/iasl.vim
+++ b/syntax_checkers/asl/iasl.vim
@@ -19,10 +19,6 @@ set cpo&vim
 
 " Checker options {{{1
 
-if !exists('g:syntastic_asl_iasl_options')
-    let g:syntastic_asl_iasl_options = ''
-endif
-
 if !exists('g:syntastic_asl_iasl_delete_output')
     let g:syntastic_asl_iasl_delete_output = 1
 endif
@@ -39,9 +35,7 @@ function! SyntaxCheckers_asl_iasl_GetLocList() dict " {{{1
         let iasl_opts .= ' -p' . syntastic#util#shescape(output_dir)
     endif
 
-    let makeprg = self.makeprgBuild({
-        \ 'args': g:syntastic_asl_iasl_options,
-        \ 'args_after': iasl_opts })
+    let makeprg = self.makeprgBuild({ 'args_after': iasl_opts })
 
     " See source/compiler/aslmessages.c for functions that produce output:
     " AePrintException, called via AslCommonError, via AslError.


### PR DESCRIPTION
ASL is the ACPI Source Language, used for firmware.

Tested with:
```
DefinitionBlock ("test.asl", "SSDT", 1, "OEM ID", "Table ID", 0x20160729)
{
    Method (LOOP)   // test.asl(3) : warning  3115 - Not all control paths return a value (LOOP)
    {
        LOOP ()     // test.asl(5) : remark   2098 - Recursive method call (LOOP)
        MISS ()     // test.asl(6) : error    6084 - Object does not exist (MISS)
        if (1) {    // test.asl(7) : optimize 1039 - Integer optimized to single-byte AML opcode (One)
            Return (Zero)
        }
    }
}
```

Command (removed `_options` since initial submissions, opting for `_args` instead):

    vim test.asl +'let g:syntastic_asl_iasl_args="-vo"' +SyntasticCheck +Errors
