### PR TITLE
Add new `fsc` checker which loads classpaths from files

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -5442,6 +5442,7 @@ SYNTAX CHECKERS FOR SCALA                           *syntastic-checkers-scala*
 The following checkers are available for Scala (filetype "scala"):
 
     1. fsc......................|syntastic-scala-fsc|
+    1. fsc-improved.............|syntastic-scala-fsc-improved|
     2. scalac...................|syntastic-scala-scalac|
     3. Scalastyle...............|syntastic-scala-scalastyle|
 
@@ -5455,6 +5456,33 @@ Checker options~
 
 This checker is initialised using the "makeprgBuild()" function and thus it
 accepts the standard options described at |syntastic-config-makeprg|.
+
+------------------------------------------------------------------------------
+1. fsc-improved                                 *syntastic-scala-fsc-improved*
+
+Name:        fsc-improved
+Maintainer:  Emily St. <github@emily.st>
+
+This checker is an improvement upon the basic `fsc` checker in that it can
+successfully pass the parser stage of compilation, provided that the
+dependencies are added to a classpath file which the checker can find.
+
+Classpath files can be built by hand or automatically by tooling.
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+Additionally:
+
+                              *'g:syntastic_scala_fsc_improved_classpath_file'*
+Type: string
+Default: ".classpath"
+Name of a file the checker should look for when trying to build the compiler's
+classpath. This allows you to add a project's dependencies, whether they be
+class files or directories with JARs within.
+
 
 ------------------------------------------------------------------------------
 2. scalac                                             *syntastic-scala-scalac*

--- a/syntax_checkers/scala/fsc-improved.vim
+++ b/syntax_checkers/scala/fsc-improved.vim
@@ -1,0 +1,90 @@
+"============================================================================
+"File:        fsc_improved
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Emily St. <hello@emily.st>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_scala_fsc_improved_checker')
+    finish
+endif
+let g:loaded_syntastic_scala_fsc_improved_checker = 1
+
+if !exists('g:syntastic_scala_fsc_improved_classpath_file')
+    let g:syntastic_scala_fsc_improved_classpath_file = '.classpath'
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_scala_fsc_improved_GetLocList() dict
+    let args = '
+        \ -Xfatal-warnings:false
+        \ -Xfuture
+        \ -Xlint
+        \ -Ywarn-adapted-args
+        \ -Ywarn-dead-code
+        \ -Ywarn-inaccessible
+        \ -Ywarn-infer-any
+        \ -Ywarn-nullary-override
+        \ -Ywarn-nullary-unit
+        \ -Ywarn-numeric-widen
+        \ -Ywarn-unused-import
+        \ -Ywarn-value-discard
+        \ -deprecation
+        \ -encoding UTF-8
+        \ -feature
+        \ -language:existentials
+        \ -language:higherKinds
+        \ -language:implicitConversions
+        \ -unchecked
+        \ -d ' . syntastic#util#tmpdir() . '
+        \ -classpath ' . s:LoadClasspathsFromFile(g:syntastic_scala_fsc_improved_classpath_file)
+
+    let makeprg = self.makeprgBuild({
+        \ 'args':  args,
+        \ 'fname': syntastic#util#shexpand('%: p') })
+
+    let errorformat =
+        \ '%E%f:%l: %trror:%m,' .
+        \ '%W%f:%l: %tarning:%m,' .
+        \ '%Z%p^,' .
+        \ '%-G%.%#,'
+
+    return SyntasticMake({
+        \ 'makeprg':     makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'scala',
+    \ 'name':     'fsc_improved',
+    \ 'exec':     'fsc' })
+
+function! s:LoadClasspathsFromFile(filename)
+    let classpath_file = syntastic#util#shexpand('%:p:h') . syntastic#util#Slash() . a:filename
+    if filereadable(classpath_file)
+        return join(readfile(classpath_file), s:ClassSep())
+    else
+        let classpath_file = syntastic#util#findFileInParent(a:filename, syntastic#util#shexpand('%:p:h'))
+        if filereadable(classpath_file)
+            return join(readfile(classpath_file), s:ClassSep())
+        else
+            return ''
+        endif
+    endif
+endfunction
+
+function! s:ClassSep()
+    return (syntastic#util#isRunningWindows() || has('win32unix')) ? ';' : ':'
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This checker uses `fsc` the same way as the standard checker, but it allows `fsc` to pass the compiler's parse stage so that better linting is available. To do this, it needs to reference the dependencies needed to build a file. It can find `.classpath` files to reference for this purpose, which the checker searches for recursively from the directory of the file it's attempting to compile.

Don't know if this is up to snuff to be included officially, but I've been using this checker for most of a year with no real issue, so I thought I'd offer it.