### PR TITLE
Add warning error format

### DIFF
--- a/syntax_checkers/scala/fsc.vim
+++ b/syntax_checkers/scala/fsc.vim
@@ -30,6 +30,7 @@ function! SyntaxCheckers_scala_fsc_GetLocList() dict
 
     let errorformat =
         \ '%E%f:%l: %trror: %m,' .
+        \ '%W%f:%l: %tarning:%m,' .
         \ '%Z%p^,' .
         \ '%-G%.%#'
 


### PR DESCRIPTION
Allows Syntastic to detect and display warnings.

I can also add a bit to allow overriding the `fsc` errorformat variable, too, if need be.