### PR TITLE
Add column range matcher for Hdevtools

### DIFF
--- a/syntax_checkers/haskell/hdevtools.vim
+++ b/syntax_checkers/haskell/hdevtools.vim
@@ -34,6 +34,7 @@ function! SyntaxCheckers_haskell_hdevtools_GetLocList() dict
         \ '%W%f:%l:%v: Warning: %m,'.
         \ '%W%f:%l:%v: Warning:,'.
         \ '%E%f:%l:%v: %m,'.
+        \ '%E%f:%l:%v-%.%#,: %m,'.
         \ '%E%>%f:%l:%v:,'.
         \ '%+C  %#%m,'.
         \ '%W%>%f:%l:%v:,'.


### PR DESCRIPTION
This pull request makes a minor change to the hdevtools syntax checker. New versions of hdevtools seem to use column ranges in some error messages. Rather than a message which starts `Filename.hs:155:11: error:`, new versions of hdevtools are outputting messages such as `Filename.hs:155:11-13: error:`.

These messages are not currently being picked-up by the existing syntax checker. This fixes this issue.