### PR TITLE
Checker luac: Fix errorformat with customized exec.

### DIFF
--- a/syntax_checkers/lua/luac.vim
+++ b/syntax_checkers/lua/luac.vim
@@ -47,7 +47,8 @@ endfunction
 function! SyntaxCheckers_lua_luac_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '-p' })
 
-    let errorformat = 'luac: %#%f:%l: %m'
+    let escapedExec = substitute(self.getExec(), '%', '%%', 'g')
+    let errorformat = '%\%%(' . escapedExec . '%\|luac%\): %#%f:%l: %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
luac has the annoying habit of prepending its executable name to all
error messages (see http://www.lua.org/source/5.3/luac.c.html#fatal and
CTRL+F `progname=`). E.g. when using

     g:syntastic_lua_luac_exec = luac52

the `errorformat` would match nothing.

E.g. the file `main.lua` containing just `0` produces the output

    luac52: main.lua:1: unexpected symbol near '0'

when checked with `luac52 -p main.lua`.