### PR TITLE
Analyze in clang_check

### DIFF
--- a/syntax_checkers/c/clang_check.vim
+++ b/syntax_checkers/c/clang_check.vim
@@ -22,11 +22,20 @@ if !exists('g:syntastic_c_clang_check_sort')
     let g:syntastic_c_clang_check_sort = 1
 endif
 
+if exists('g:syntastic_clang_check_analyze') &&
+   \ g:syntastic_clang_check_analyze == 1
+    let g:syntastic_clang_check_analyze_str = '-analyze'
+else
+    let g:syntastic_clang_check_analyze_str = ''
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_c_clang_check_GetLocList() dict
     let makeprg = self.makeprgBuild({
+        \ 'args_before':
+        \   g:syntastic_clang_check_analyze_str,
         \ 'post_args':
         \   '-- ' .
         \   syntastic#c#ReadConfig(g:syntastic_clang_check_config_file) . ' ' .


### PR DESCRIPTION
Adding support for enabling clang_check analyze, which produces completely different warnings in source code.  Makes this error show up in the editor properly:

```
test.c:13:14: warning: The left operand of '<' is a garbage value
    for(i; i < 10; i++)
```
![capture](https://cloud.githubusercontent.com/assets/8534/19023351/fed1b1a2-88ba-11e6-9493-4f115fa8161e.JPG)
![capture2](https://cloud.githubusercontent.com/assets/8534/19023359/2601904e-88bb-11e6-8a4c-3599de49bfdc.JPG)

Perhaps the way the options are set up should be tweaked a bit, but nothing breaks and it works as expected if g:syntastic_clang_check_analyze is unset, set to 0 or set to 1.  Also, maybe it should be set up to use ReadConfig so c and cpp could have different options.
