### PR TITLE
Enabling Racket checker do work without running the code

### DIFF
--- a/syntax_checkers/racket/racket.vim
+++ b/syntax_checkers/racket/racket.vim
@@ -20,12 +20,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_racket_racket_GetLocList() dict
-    let makeprg = self.makeprgBuild({})
+    let makeprg = self.makeprgBuild({'args' : 'make'})
 
     " example of error message
     "eval-apply.rkt:460:30: the-empty-environment: unbound identifier in module
     "  in: the-empty-environment
-    let errorformat = '%f:%l:%v: %m'
+    let errorformat = '%f:%l:%v: %m, %m'
 
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
@@ -43,6 +43,7 @@ endfunction
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'racket',
     \ 'name': 'racket',
+    \ 'exec': 'raco',    
     \ 'enable': 'enable_racket_racket_checker' })
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
The change I propose uses `raco make` instead of just running the code. This might be a controversial change for some people because in case of smaller scripts running the code takes no time and can actually uncover more bugs. However that's not the case for every program and using raco is more universal -- will work for all files and does not carry the risk of blocking Vim (now that syntastic doesn't use Vim 8 async yet) by "checking" a program with long running time.
I also changed the error format to include all lines in Racket's error output. As it is the messages shown by Syntastic often arent informative enough and one must run the code again in DrRacket to get to the core of the problem.