### PR TITLE
Added golang build flag for massive speedup

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -54,7 +54,7 @@ function! SyntaxCheckers_go_go_GetLocList() dict
     " Test files, i.e. files with a name ending in `_test.go`, are not
     " compiled by `go build`, therefore `go test` must be called for those.
     if match(expand('%', 1), '\m_test\.go$') == -1
-        let cmd = 'build'
+        let cmd = 'build -i'
         let opts = syntastic#util#var('go_go_build_args', s:go_new ? '-buildmode=archive' : '')
         let cleanup = 0
     else


### PR DESCRIPTION
Until now, writing to any golang file would run a go guild
command that would take up to 10 seconds during which the
editor would be essentially frozen. By using the -i flag,
any subsequent writes to that file will be almost instantaneous.