### PR TITLE
Do not assume we are assembling to an ELF

### DIFF
--- a/syntax_checkers/nasm/nasm.vim
+++ b/syntax_checkers/nasm/nasm.vim
@@ -20,7 +20,7 @@ set cpo&vim
 
 function! SyntaxCheckers_nasm_nasm_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '-X gnu -f elf' .
+        \ 'args_after': '-X gnu' .
         \       ' -I ' . syntastic#util#shescape(expand('%:p:h', 1) . syntastic#util#Slash()) .
         \       ' ' . syntastic#c#NullOutput() })
 


### PR DESCRIPTION
This disallows things like the org directive, which are perfectly normal in other formats. It's better to just not specify, and give the user the option to add their format to the *_args variable, if they want.