### PR TITLE
Checker python/mypy: allow return code 2

### DIFF
--- a/syntax_checkers/python/mypy.vim
+++ b/syntax_checkers/python/mypy.vim
@@ -29,7 +29,7 @@ function! SyntaxCheckers_python_mypy_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'returns': [0, 1],
+        \ 'returns': [0, 1, 2],
         \ 'preprocess': 'mypy' })
 endfunction
 


### PR DESCRIPTION
Allow mypy checker to return status code 2 on Python syntax error.

The issue is encountered if a previous checker does not catch the syntax error.