### PR TITLE
Add syntax checker for avra, an AVR assembler

### DIFF
--- a/syntax_checkers/avra/avra.vim
+++ b/syntax_checkers/avra/avra.vim
@@ -1,0 +1,39 @@
+"============================================================================
+"File:        avra.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  Utkarsh Verma <utkarshverma@protonmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_avra_avra_checker')
+    finish
+endif
+let g:loaded_syntastic_avra_avra_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_avra_avra_GetLocList() dict
+    let buf = bufnr('')
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f\(%l\) : %trror   : %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'avra',
+    \ 'name': 'avra'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
This PR adds support for [`avra`](https://github.com/Ro5bert/avra), an AVR assembler. It works well.

![image](https://user-images.githubusercontent.com/31820255/137265304-e53f2792-b2ad-4f72-b007-6de85fecb2d1.png)
