### PR TITLE
Checker ruby/mri: Remove -T1 flag

### DIFF
--- a/syntax_checkers/ruby/mri.vim
+++ b/syntax_checkers/ruby/mri.vim
@@ -37,7 +37,7 @@ endfunction
 
 function! SyntaxCheckers_ruby_mri_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '-w -T1',
+        \ 'args': '-w',
         \ 'args_after': '-c' })
 
     "this is a hack to filter out a repeated useless warning in rspec files


### PR DESCRIPTION
The flag has been removed in https://github.com/ruby/ruby/commit/0dbf6e46fb88a1c8c48ce5f67ac881a77de76526 and that was released in Ruby 3.0.0.

---

```
syntastic: 0.038401: g:syntastic_version = '3.10.0-32 (Vim 802, Darwin, GUI)'
syntastic: 0.038480: &shell = '/opt/homebrew/bin/bash', &shellcmdflag = '-c', &shellpipe = '2>&1| tee', &shellquote = '', &shellredir = '>%s 2>&1'
, &shelltemp = 1, &shellxquote = '', &autochdir = 0, &shellxescape = ''
syntastic: 0.038723: UpdateErrors: default checkers
syntastic: 0.038846: CacheErrors: default checkers
syntastic: 0.039134: g:syntastic_aggregate_errors = 0
syntastic: 0.039228: getcwd() = '/private/tmp'
syntastic: 0.041101: CacheErrors: Invoking checker: ruby/mri
syntastic: 0.041354: SyntasticMake: called with options: {'errorformat': '%-G%\m%.%#warning: %\%%(possibly %\)%\?useless use of == in void context
,%-G%\%.%\%.%\%.%.%#,%-GSyntax OK,%E%f:%l: syntax error\, %m,%Z%p^,%W%f:%l: warning: %m,%Z%p^,%W%f:%l: %m,%-C%.%#', 'makeprg': 'ruby -w -T1 -c dem
o.rb', 'env': {'RUBYOPT': ''}}
syntastic: 0.049618: system: command run in 0.008098s
syntastic: 0.049684: checker output: ['ruby: invalid option -T  (-h will show valid options) (RuntimeError)', '']
syntastic: 0.050140: raw loclist: [{'lnum': 0, 'bufnr': 0, 'end_lnum': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'module': '', 'type': '', 'col': 0, 'en
d_col': 0, 'pattern': '', 'text': 'ruby: invalid option -T  (-h will show valid options) (RuntimeError)'}, {'lnum': 0, 'bufnr': 0, 'end_lnum': 0,
'valid': 0, 'vcol': 0, 'nr': -1, 'module': '', 'type': '', 'col': 0, 'end_col': 0, 'pattern': '', 'text': ''}]
syntastic: 0.050250: getLocList: checker ruby/mri returned 1
syntastic: 0.050309: ruby/mri raw: [{'lnum': 0, 'bufnr': 0, 'end_lnum': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'module': '', 'type': '', 'col': 0, 'e
nd_col': 0, 'pattern': '', 'text': 'ruby: invalid option -T  (-h will show valid options) (RuntimeError)'}, {'lnum': 0, 'bufnr': 0, 'end_lnum': 0,
 'valid': 0, 'vcol': 0, 'nr': -1, 'module': '', 'type': '', 'col': 0, 'end_col': 0, 'pattern': '', 'text': ''}]
syntastic: 0.050402: quiet_messages filter: {}
syntastic: 0.050449: getLocList: checker ruby/mri run in 0.009298s
syntastic: 0.050559: aggregated: {'_sorted': 0, '_name': '', '_owner': 1, '_columns': 1, '_rawLoclist': []}
```